### PR TITLE
rtp may contain trailing slash.

### DIFF
--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -3003,7 +3003,7 @@ endfu
 
 let g:JavaComplete_Home = ''
 for path in split(&rtp, ',')
-  if match(path, "vim-javacomplete2$") >= 0
+  if match(path, "vim-javacomplete2/*$") >= 0
     let g:JavaComplete_Home = path
     break
   endif


### PR DESCRIPTION
neobundle adds trailing slash to rtp.

In my environment, &rtp is:
```
/Users/tokuhirom/.vim,/Users/tokuhirom/.vim/bundle/vim-javacomplete2/
```