### PR TITLE
fix spawn java

### DIFF
--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -93,6 +93,7 @@ let s:RE_CASTING	= '^\s*(\(' .s:RE_QUALID. '\))\s*\(' . s:RE_IDENTIFIER . '\)\>'
 
 let s:RE_KEYWORDS	= '\<\%(' . join(s:KEYWORDS, '\|') . '\)\>'
 
+let s:JAVA_HOME = $JAVA_HOME
 
 " local variables						{{{1
 let b:context_type = s:CONTEXT_OTHER
@@ -1987,16 +1988,17 @@ fu! s:GetClassPath()
   endif
 
   if empty($CLASSPATH)
-    let java = javacomplete#GetJVMLauncher()
-    call s:Info(exepath(java))
-    let javaSettings = split(s:System(java. " -XshowSettings", "Get java settings"), '\n')
-    for line in javaSettings
-      if line =~ 'java\.home'
-        let javaHome = split(line, ' = ')
-        return path. javaHome[1]. '/lib'
-      endif
-    endfor
-    
+    if s:JAVA_HOME == ''
+      let java = javacomplete#GetJVMLauncher()
+      call s:Info(exepath(java))
+      let javaSettings = split(s:System(java. " -XshowSettings", "Get java settings"), '\n')
+      for line in javaSettings
+        if line =~ 'java\.home'
+          let s:JAVA_HOME = split(line, ' = ')[1]
+        endif
+      endfor
+    endif
+    return path. s:JAVA_HOME. '/lib'
   endif
 
   return path . $CLASSPATH

--- a/autoload/javavibridge.py
+++ b/autoload/javavibridge.py
@@ -21,7 +21,7 @@ class JavaviBridge():
     popen = None
 
     def setupServer(self, javabin, args):
-        self.popen = SafePopen([javabin + ' ' + args + ' ' + str(SERVER[1])], shell=True, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
+        self.popen = SafePopen(javabin + ' ' + args + ' ' + str(SERVER[1]), shell=True, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
 
     def pid(self):
         return self.popen.pid


### PR DESCRIPTION
if specify `shell = True`, it don't need to pass as list to args. on windows, it doesn't work.
and also, java is spawning multiple times to get JAVA_HOME. it should be cached.