### PR TITLE
fix spawning java

### DIFF
--- a/autoload/javavibridge.py
+++ b/autoload/javavibridge.py
@@ -30,7 +30,7 @@ class JavaviBridge():
     popen = None
 
     def setupServer(self, javabin, args):
-        self.popen = SafePopen([javabin + ' ' + args + ' ' + str(SERVER[1])], shell=True, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
+        self.popen = SafePopen(javabin + ' ' + args + ' ' + str(SERVER[1]), shell=True, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
 
     def pid(self):
         return self.popen.pid


### PR DESCRIPTION
* CLASSPATH is too long. On windows, failure to spwan if ~/.m2/repository has many jars.
* if shell = True, it don't need to specify args as list.
* spawning java to get JAVA_HOME should be cached.