### PR TITLE
Store maven dependencies in cache file.

### DIFF
--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -2107,7 +2107,16 @@ function! s:FindClassPath() abort
         return join(readfile(path), '')
       endif
     endif
-    return s:GenerateClassPath(path)
+
+    let pomcachedir = expand('~/.javacomplete2/pomcache/')
+    let pomcachefile = pomcachedir . split(system('md5sum ' . pom))[0]
+    if !isdirectory(pomcachedir)
+      call mkdir(pomcachedir, "p")
+    endif
+    if !filereadable(pomcachefile)
+      call writefile([s:GenerateClassPath(path)], pomcachefile)
+    endif
+    return readfile(pomcachefile)[0]
   else
     return '.'
   endif


### PR DESCRIPTION
I use javacomplete2 for my daily work now, it's great!
this is a small patch: we can store maven dependency:build-classpath result into cache file, so that we don't need to run maven (very slow) each time we load javacomplete2.
-- Zhang Li