### PR TITLE
Ignore doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ libs/javavi/target/
 
 *.lock
 .vim-flavor
+
+doc/tags


### PR DESCRIPTION
Git keeps showing me the vim-javacomplete2 submodule as dirty everytime I open vim because doc/tags gets updated.