### PR TITLE
Fix path to pom.xml

### DIFF
--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -210,7 +210,7 @@ if !exists('g:JavaComplete_MavenRepositoryDisable') || !g:JavaComplete_MavenRepo
   endif
 
   if !exists('g:JavaComplete_PomPath')
-    let g:JavaComplete_PomPath = findfile('pom.xml', escape(expand('.'), '*[]?{}, ') . ';')
+    let g:JavaComplete_PomPath = fnamemodify(findfile('pom.xml', escape(expand('.'), '*[]?{}, ') . ';'), ':p')
   endif
 
   if g:JavaComplete_PomPath != ""

--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -111,7 +111,7 @@ endfunction
 function! s:FindClassPath() abort
   if executable('mvn')
     let base = s:GetBase("mvnclasspath/")
-    let key = substitute(g:JavaComplete_PomPath, g:FILE_SEP, '_', 'g')
+    let key = substitute(g:JavaComplete_PomPath, '[\\/:;]', '_', 'g')
     let path = base . key
 
     if g:JavaComplete_PomPath != "" && filereadable(path)

--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -129,7 +129,7 @@ function! s:GenerateClassPath(path, pom) abort
   let lines = split(system('mvn --file ' . a:pom . ' dependency:build-classpath -DincludeScope=test'), "\n")
   for i in range(len(lines))
     if lines[i] =~ 'Dependencies classpath:'
-      let cp = lines[i+1]
+      let cp = lines[i+1] . g:PATH_SEP . join([fnamemodify(a:pom, ':h'), 'target', 'classes'], g:FILE_SEP)
       call writefile([cp], a:path)
       return cp
     endif

--- a/autoload/javacomplete/server.vim
+++ b/autoload/javacomplete/server.vim
@@ -246,7 +246,13 @@ function! s:GetExtraPath()
   if exists('g:JavaComplete_LibsPath')
     let paths = split(g:JavaComplete_LibsPath, g:PATH_SEP)
     for path in paths
-      call extend(jars, s:ExpandPathToJars(path))
+      let exp = s:ExpandPathToJars(path)
+      if empty(exp)
+        " ex: target/classes
+        call extend(jars, [path])
+      else
+        call extend(jars, exp)
+      endif
     endfor
   endif
 


### PR DESCRIPTION
When getcwd() is same as pom.xml, `g:JavaComplete_PomPath` become `.`.
Should be absolute path.
