### PR TITLE
Fix completion of incomplete

### DIFF
--- a/autoload/javacomplete/complete.vim
+++ b/autoload/javacomplete/complete.vim
@@ -36,22 +36,7 @@ function! javacomplete#complete#Complete(findstart, base)
     let s:et_whole = reltime()
     let start = col('.') - 1
 
-    if javacomplete#util#GetClassNameWithScope() =~ '^[@A-Z][A-Za-z0-9_]*$'
-      let b:context_type = s:CONTEXT_COMPLETE_CLASS
-
-      let curline = getline(".")
-      let start = col('.') - 1
-
-      while start > 0 && curline[start - 1] =~ '[@A-Za-z0-9_]'
-        let start -= 1
-        if curline[start] == '@'
-          break
-        endif
-      endwhile
-
-      return start
-
-    elseif statement =~ '[.0-9A-Za-z_]\s*$'
+    if statement =~ '[.0-9A-Za-z_]\s*$'
       let valid = 1
       if statement =~ '\.\s*$'
         let valid = statement =~ '[")0-9A-Za-z_\]]\s*\.\s*$' && statement !~ '\<\H\w\+\.\s*$' && statement !~ '\C\<\(abstract\|assert\|break\|case\|catch\|const\|continue\|default\|do\|else\|enum\|extends\|final\|finally\|for\|goto\|if\|implements\|import\|instanceof\|interface\|native\|new\|package\|private\|protected\|public\|return\|static\|strictfp\|switch\|synchronized\|throw\|throws\|transient\|try\|volatile\|while\|true\|false\|null\)\.\s*$'
@@ -157,6 +142,20 @@ function! javacomplete#complete#Complete(findstart, base)
       let b:context_type = s:CONTEXT_METHOD_REFERENCE
       let b:dotexpr = javacomplete#scanner#ExtractCleanExpr(statement)
       return start - strlen(b:incomplete)
+	elseif javacomplete#util#GetClassNameWithScope() =~ '^[@A-Z][A-Za-z0-9_]*$'
+      let b:context_type = s:CONTEXT_COMPLETE_CLASS
+
+      let curline = getline(".")
+      let start = col('.') - 1
+
+      while start > 0 && curline[start - 1] =~ '[@A-Za-z0-9_]'
+        let start -= 1
+        if curline[start] == '@'
+          break
+        endif
+      endwhile
+
+      return start
     endif
 
     return -1
@@ -320,7 +319,7 @@ function! s:CompleteAfterWord(incomplete)
     for dirpath in s:GetSourceDirs(expand('%:p'))
       let filepatterns .= escape(dirpath, ' \') . '/**/*.java '
     endfor
-    exe 'vimgrep /\s*' . g:RE_TYPE_DECL . '/jg ' . filepatterns
+    silent! exe 'vimgrep /\s*' . g:RE_TYPE_DECL . '/jg ' . filepatterns
     for item in getqflist()
       if item.text !~ '^\s*\*\s\+'
         let text = matchstr(javacomplete#util#Prune(item.text, -1), '\s*' . g:RE_TYPE_DECL)


### PR DESCRIPTION
When class `Foo` have `getMessage`, completion on `new Foo().ge|` fail.
Because javacomplete2 plugin detect `ge` as class name incomplete. then finding class `ge*`.

I moved this part at last of case which checking completion-method.
