### PR TITLE
Adds support for all Gradle classpaths

### DIFF
--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -325,7 +325,11 @@ if !exists('g:JavaComplete_MavenRepositoryDisable') || !g:JavaComplete_MavenRepo
   endif
 
   if !exists('g:JavaComplete_GradlePath')
-    let g:JavaComplete_GradlePath = findfile('build.gradle', escape(getcwd(), '*[]?{}, ') . ';')
+    if filereadable(getcwd() . "/build.gradle")
+      let g:JavaComplete_GradlePath = getcwd() . "/build.gradle"
+    else
+      let g:JavaComplete_GradlePath = findfile('build.gradle', escape(expand('.'), '*[]?{}, ') . ';')
+    endif
     if g:JavaComplete_GradlePath != ""
       let g:JavaComplete_GradlePath = fnamemodify(g:JavaComplete_GradlePath, ':p')
     endif

--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -184,8 +184,8 @@ endfunction
 function! s:GenerateGradleClassPath(path, gradle) abort
   try
     let f = tempname()
-    call writefile(readfile(a:gradle) + ["println 'CLASSPATH:' + sourceSets['main']['compileClasspath'].collect { n -> n.absolutePath }.join(File.pathSeparator)"], f)
-    let ret = system('gradle -q -b ' . shellescape(f))
+    call writefile(["allprojects{apply from: '" . g:JavaComplete_Home . "/classpath.gradle'}"], f)
+    let ret = system('gradle -q -i ' . shellescape(f) . ' classpath' )
     if v:shell_error == 0
       let cp = filter(split(ret, "\n"), 'v:val =~ "^CLASSPATH:"')[0][10:]
       call writefile([cp], a:path)
@@ -313,7 +313,7 @@ if !exists('g:JavaComplete_MavenRepositoryDisable') || !g:JavaComplete_MavenRepo
   endif
 
   if !exists('g:JavaComplete_GradlePath')
-    let g:JavaComplete_GradlePath = findfile('build.gradle', escape(expand('.'), '*[]?{}, ') . ';')
+    let g:JavaComplete_GradlePath = findfile('build.gradle', escape(getcwd(), '*[]?{}, ') . ';')
     if g:JavaComplete_GradlePath != ""
       let g:JavaComplete_GradlePath = fnamemodify(g:JavaComplete_GradlePath, ':p')
     endif

--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -144,16 +144,18 @@ function! s:FindClassPath() abort
     return s:GenerateMavenClassPath(path, g:JavaComplete_PomPath)
   endif
 
-  if executable('gradle') && g:JavaComplete_GradlePath != ""
-    let key = substitute(g:JavaComplete_GradlePath, '[\\/:;]', '_', 'g')
-    let path = base . key
+  if executable('gradle') || executable('gradlew')
+    if g:JavaComplete_GradlePath != ""
+      let key = substitute(g:JavaComplete_GradlePath, '[\\/:;]', '_', 'g')
+      let path = base . key
 
-    if filereadable(path)
-      if getftime(path) >= getftime(g:JavaComplete_GradlePath)
-        return join(readfile(path), '')
+      if filereadable(path)
+        if getftime(path) >= getftime(g:JavaComplete_GradlePath)
+          return join(readfile(path), '')
+        endif
       endif
+      return s:GenerateGradleClassPath(path, g:JavaComplete_GradlePath)
     endif
-    return s:GenerateGradleClassPath(path, g:JavaComplete_GradlePath)
   endif
 
   if has('python') || has('python3')
@@ -184,8 +186,18 @@ endfunction
 function! s:GenerateGradleClassPath(path, gradle) abort
   try
     let f = tempname()
+    let gradle = ''
+    if executable('./gradlew')
+      if has("win32") || has("win16")
+        let gradle = 'gradle.bat'
+      else
+        let gradle = './gradlew'
+      endif
+    else
+      let gradle = 'gradle'
+    endif
     call writefile(["allprojects{apply from: '" . g:JavaComplete_Home . "/classpath.gradle'}"], f)
-    let ret = system('gradle -q -i ' . shellescape(f) . ' classpath' )
+    let ret = system(gradle . ' -q -i ' . shellescape(f) . ' classpath' )
     if v:shell_error == 0
       let cp = filter(split(ret, "\n"), 'v:val =~ "^CLASSPATH:"')[0][10:]
       call writefile([cp], a:path)

--- a/classpath.gradle
+++ b/classpath.gradle
@@ -1,0 +1,40 @@
+task classpath << {
+
+  String finalFileContents = ""
+  HashSet<String> classpathFiles = new HashSet<String>()
+  for (proj in allprojects) {
+    
+    def exploded = proj.getBuildDir().absolutePath + File.separator + "intermediates" + File.separator + "exploded-aar"
+    def listFiles = new File(exploded)
+    if (listFiles.exists()) {
+      listFiles.eachFileRecurse(){ file ->
+        if (file.name.endsWith("classes.jar")){
+          classpathFiles += file
+        }
+      }
+    }
+
+    for (conf in proj.configurations) {
+        for (dependency in conf) {
+            if (dependency.name.endsWith("aar")){
+            } else {
+              classpathFiles += dependency
+            }
+        }
+    }
+    if (proj.hasProperty("android")){
+      classpathFiles += proj.android.bootClasspath
+    }
+
+    if (proj.hasProperty("sourceSets")) {
+    
+      for (srcSet in proj.sourceSets) {
+          for (dir in srcSet.java.srcDirs) {
+              classpathFiles += dir.absolutePath
+          }
+      }
+    }
+  }
+  def paths = classpathFiles.join(File.pathSeparator)
+  println "CLASSPATH:" + paths
+}


### PR DESCRIPTION
Before this commit, the Gradle classpath was only pulled from the "main"
project. This commit has Gradle run a custom task that outputs all jars
from all projects. It also grabs the exploded aars and android.jar for
the given project and thus adds Android support.