### PR TITLE
Fix PomPath issue

### DIFF
--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -390,7 +390,7 @@ if !exists('g:JavaComplete_MavenRepositoryDisable') || !g:JavaComplete_MavenRepo
   endif
 
   if !exists('g:JavaComplete_PomPath')
-    let g:JavaComplete_PomPath = findfile('pom.xml', escape(expand('.'), '*[]?{}, ') . ';')
+    let g:JavaComplete_PomPath = javacomplete#util#findFile('pom.xml')
     if g:JavaComplete_PomPath != ""
       let g:JavaComplete_PomPath = fnamemodify(g:JavaComplete_PomPath, ':p')
     endif

--- a/autoload/javacomplete/util.vim
+++ b/autoload/javacomplete/util.vim
@@ -186,4 +186,12 @@ function! javacomplete#util#CleanFQN(fqnDeclaration)
   return fqnDeclaration
 endfunction
 
+function! javacomplete#util#findFile(what) abort
+  let old_suffixesadd = &suffixesadd
+  let &suffixesadd = ''
+  let file = findfile(a:what, ',;')
+  let &suffixesadd = old_suffixesadd
+  return file
+endfunction
+
 " vim:set fdm=marker sw=2 nowrap:

--- a/autoload/javacomplete/util.vim
+++ b/autoload/javacomplete/util.vim
@@ -188,10 +188,12 @@ endfunction
 
 function! javacomplete#util#findFile(what) abort
   let old_suffixesadd = &suffixesadd
-  let &suffixesadd = ''
-  let file = findfile(a:what, ',;')
-  let &suffixesadd = old_suffixesadd
-  return file
+  try
+    let &suffixesadd = ''
+    return findfile(a:what, ',;')
+  finally
+    let &suffixesadd = old_suffixesadd
+  endtry
 endfunction
 
 " vim:set fdm=marker sw=2 nowrap:


### PR DESCRIPTION
if open a new java file in a new directory,the plugin can not find the
pom.xml.

test example:
1. vim src/main/java/com/test/newdir/Foo.java
2. echo g:JavaComplete_PomPath
show me only a dot

after this PR; show me the whole path of pom.xml