### PR TITLE
Fix  :message format

### DIFF
--- a/autoload/javacomplete/classpath/gradle.vim
+++ b/autoload/javacomplete/classpath/gradle.vim
@@ -36,12 +36,16 @@ function! javacomplete#classpath#gradle#BuildClasspathHandler(jobId, data, event
     unlet s:gradlePath
 
   elseif a:event == 'stdout'
-    echom join(a:data)
+    for data in filter(a:data,'v:val !~ "^\\s*$"')
+        echomsg data
+    endfor
     if exists('s:gradleOutput')
       call extend(s:gradleOutput, a:data)
     endif
   elseif a:event == 'stderr'
-    echoerr join(a:data)
+    for data in filter(a:data,'v:val !~ "^\\s*$"')
+        echoerr data
+    endfor
   endif
 endfunction
 

--- a/autoload/javacomplete/classpath/maven.vim
+++ b/autoload/javacomplete/classpath/maven.vim
@@ -94,10 +94,14 @@ function! javacomplete#classpath#maven#BuildClasspathHandler(jobId, data, event)
     unlet s:mavenPom
     unlet s:mavenSettingsOutput
   elseif a:event == 'stdout'
-    echom join(a:data)
+    for data in filter(a:data,'v:val !~ "^\\s*$"')
+        echomsg data
+    endfor
     call extend(s:mavenSettingsOutput, a:data)
   elseif a:event == 'stderr'
-    echoerr join(a:data)
+    for data in filter(a:data,'v:val !~ "^\\s*$"')
+        echoerr data
+    endfor
   endif
 endfunction
 


### PR DESCRIPTION
in neovim ,after complile project,the `:message`'s format is error,~~we should spild them by line~~,here I just output them one by one ,and do not add any newline,and remove empty line(because stdout sometimes show unuseful empty line)
before this PR `:message` show like this
![2016-02-25 00-46-12](https://cloud.githubusercontent.com/assets/13142418/13293529/f6321eb4-db5a-11e5-925b-ecc27547e992.png)


after this PR,looks better
![2016-02-25 01-01-39](https://cloud.githubusercontent.com/assets/13142418/13293641/65a36d16-db5b-11e5-9003-e46d30918321.png)


