### PR TITLE
Import sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ To remove all missing imports with F6:
 
 `let g:JavaComplete_GradleExecutable = 'gradle'` - use your own path to gradle executable file.
 
+`let g:JavaComplete_ImportOrder = ['java.', 'javax.', 'com.', 'org.', 'net.']` - Specifies the order of import groups. An import group is a list of individual import statements that all start with the same beginning of package name surrounded by blank lines above and below the group.
+
 ## Commands
 
 `JCimportsAddMissing` - add all missing 'imports';

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Features:
 - Nested classes;
 - Adding imports automatically, includes `static` imports and imports of nested classes;
 - Complete methods declaration after '@Override';
-- Jsp support, without taglibs.
+- Jsp support, without taglibs;
+- Cross-session cache.
 
 Features (originally existed):
 - List members of a class, including (static) fields, (static) methods and ctors;
@@ -94,23 +95,29 @@ Add this to your `.vimrc` file:
 
 `autocmd FileType java setlocal omnifunc=javacomplete#Complete`
 
-To enable inserting class imports with F4, add:
+To enable smart (trying to guess import option) inserting class imports with F4, add:
 
-`nmap <F4> <Plug>(JavaComplete-Imports-Add)`
+`nmap <F4> <Plug>(JavaComplete-Imports-AddSmart)`
 
-`imap <F4> <Plug>(JavaComplete-Imports-Add)`
+`imap <F4> <Plug>(JavaComplete-Imports-AddSmart)`
 
-To add all missing imports with F5:
+To enable usual (will ask for import option) inserting class imports with F5, add:
 
-`nmap <F5> <Plug>(JavaComplete-Imports-AddMissing)`
+`nmap <F5> <Plug>(JavaComplete-Imports-Add)`
 
-`imap <F5> <Plug>(JavaComplete-Imports-AddMissing)`
+`imap <F5> <Plug>(JavaComplete-Imports-Add)`
 
-To remove all missing imports with F6:
+To add all missing imports with F6:
 
-`nmap <F6> <Plug>(JavaComplete-Imports-RemoveUnused)`
+`nmap <F6> <Plug>(JavaComplete-Imports-AddMissing)`
 
-`imap <F6> <Plug>(JavaComplete-Imports-RemoveUnused)`
+`imap <F6> <Plug>(JavaComplete-Imports-AddMissing)`
+
+To remove all missing imports with F7:
+
+`nmap <F7> <Plug>(JavaComplete-Imports-RemoveUnused)`
+
+`imap <F7> <Plug>(JavaComplete-Imports-RemoveUnused)`
 
 ### Optional
 
@@ -136,7 +143,11 @@ To remove all missing imports with F6:
 
 `let g:JavaComplete_GradleExecutable = 'gradle'` - use your own path to gradle executable file.
 
-`let g:JavaComplete_ImportOrder = ['java.', 'javax.', 'com.', 'org.', 'net.']` - Specifies the order of import groups. An import group is a list of individual import statements that all start with the same beginning of package name surrounded by blank lines above and below the group.
+`let g:JavaComplete_ImportSortType = 'jarName'` - imports sorting type. Sorting can be by jar archives `jarName` or by package names `packageName`.
+
+`let g:JavaComplete_ImportOrder = ['java.', 'javax.', 'com.', 'org.', 'net.']` - Specifies the order of import groups, when use `packageName` sorting type. An import group is a list of individual import statements that all start with the same beginning of package name surrounded by blank lines above and below the group.
+
+`let g:JavaComplete_RegularClasses = ['java.lang.String', 'java.lang.Object']` - Regular class names that will be used automatically when you insert import. You can populate it with your custom classes, or it will be populated automatically when you choose any import option. List will be persisted, so it will be used next time you run the same project.
 
 ## Commands
 
@@ -146,7 +157,7 @@ To remove all missing imports with F6:
 
 `JCimportAdd` - add 'import' for classname that is under cursor, or before it;
 
-`JCimportAddI` - the same, but enable insert mode after 'import' was added;
+`JCimportAddSmart` - add 'import' for classname trying to guess variant without ask user to choose an option (it will ask on false guessing).
 
 
 `JCserverShowPort` - show port, through which vim plugin communicates with server;
@@ -178,7 +189,7 @@ To remove all missing imports with F6:
 
 - Add javadoc;
 - ~~Lambda support~~;
-- Cross session cache;
+- ~~Cross session cache~~;
 - Most used (classes, methods, vars) at first place (smart suggestions);
 - FXML support;
 - ~~Check for jsp support~~;

--- a/autoload/javacomplete/classpath/classpath.vim
+++ b/autoload/javacomplete/classpath/classpath.vim
@@ -66,6 +66,9 @@ function! s:FindClassPath() abort
   for classpathSourceType in g:JavaComplete_ClasspathGenerationOrder
     try
       exec "let cp .= s:Use". classpathSourceType. "()"
+      if cp != '.'
+        break
+      endif
     catch
     endtry
   endfor

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -183,8 +183,6 @@ function! s:SortImports()
     endfor
 
     call sort(importsList)
-    "TODO sort imports
-    "call s:sort(importsList)
     let importsList_sorted = []
     for a in g:JavaComplete_ImportOrder
       let l_a = filter(copy(importsList),"v:val =~? '^" . a . "\\.'")
@@ -200,7 +198,7 @@ function! s:SortImports()
       for imp in importsList
         call add(importsList_sorted, imp)
       endfor
-    else
+    elseif len(importsList_sorted) > 0
       call remove(importsList_sorted, -1)
     endif
 

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -1,5 +1,5 @@
 " Vim completion script for java
-" Maintainer:	artur shaik <ashaihullin@gmail.com>
+" Maintainer:   artur shaik <ashaihullin@gmail.com>
 "
 " Everything to work with imports
 
@@ -80,10 +80,10 @@ endfunction
 function! javacomplete#imports#GetImports(kind, ...)
   let filekey = a:0 > 0 && !empty(a:1) ? a:1 : javacomplete#GetCurrentFileKey()
   let props = get(g:JavaComplete_Files, filekey, {})
-  let props['imports']	= filekey == javacomplete#GetCurrentFileKey() ? s:GenerateImports() : props.unit.imports
-  let props['imports_static']	= []
-  let props['imports_fqn']	= []
-  let props['imports_star']	= ['java.lang.']
+  let props['imports']  = filekey == javacomplete#GetCurrentFileKey() ? s:GenerateImports() : props.unit.imports
+  let props['imports_static']   = []
+  let props['imports_fqn']  = []
+  let props['imports_star'] = ['java.lang.']
   if &ft == 'jsp' || filekey =~ '\.jsp$'
     let props.imports_star += ['javax.servlet.', 'javax.servlet.http.', 'javax.servlet.jsp.']
   endif
@@ -110,7 +110,7 @@ function! javacomplete#imports#GetImports(kind, ...)
   return get(props, a:kind, [])
 endfu
 
-" search for name in 
+" search for name in
 " return the fqn matched
 function! javacomplete#imports#SearchSingleTypeImport(name, fqns)
   let matches = s:filter(a:fqns, 'item =~# ''\<' . a:name . '$''')
@@ -127,10 +127,10 @@ endfu
 " return [types, methods, fields]
 function! javacomplete#imports#SearchStaticImports(name, fullmatch)
   let result = [[], [], []]
-  let candidates = []		" list of the canonical name
+  let candidates = []       " list of the canonical name
   for item in javacomplete#imports#GetImports('imports_static')
     call javacomplete#logger#Log(item)
-    if item[-1:] == '*'		" static import on demand
+    if item[-1:] == '*'     " static import on demand
       call add(candidates, item[:-3])
     elseif item[strridx(item, '.')+1:] ==# a:name
           \ || (!a:fullmatch && item[strridx(item, '.')+1:] =~ '^' . a:name)
@@ -178,18 +178,43 @@ function! s:SortImports()
     let beginLine = imports[0][1]
     let lastLine = imports[len(imports) - 1][1]
     let importsList = []
-    for import in imports 
+    for import in imports
       call add(importsList, import[0])
     endfor
 
     call sort(importsList)
+    "TODO sort imports
+    "call s:sort(importsList)
+    let importsList_sorted = []
+    for a in g:JavaComplete_ImportOrder
+      let l_a = filter(copy(importsList),'v:val =~? "^' . a . '\\."')
+      if len(l_a) > 0
+        for imp in l_a
+          call remove(importsList, index(importsList, imp))
+          call add(importsList_sorted, imp)
+        endfor
+        call add(importsList_sorted, '')
+      endif
+    endfor
+    if len(importsList) > 0
+      for imp in importsList
+        call add(importsList_sorted, imp)
+      endfor
+    else
+      call remove(importsList_sorted, -1)
+    endif
+
     let saveCursor = getpos('.')
     silent execute beginLine.','.lastLine. 'delete _'
-    for imp in importsList
-      if &ft == 'jsp'
-        call append(beginLine - 1, '<%@ page import = "'. imp. '" %>')
+    for imp in importsList_sorted
+      if imp != ''
+        if &ft == 'jsp'
+          call append(beginLine - 1, '<%@ page import = "'. imp. '" %>')
+        else
+          call append(beginLine - 1, 'import '. imp. ';')
+        endif
       else
-        call append(beginLine - 1, 'import '. imp. ';')
+          call append(beginLine - 1, '')
       endif
       let beginLine += 1
     endfor
@@ -281,7 +306,7 @@ function! javacomplete#imports#Add(...)
   while empty(classname)
     let offset = col('.') - i
     if offset <= 0
-      return 
+      return
     endif
     let classname = javacomplete#util#GetClassNameWithScope(offset)
     let i += 1
@@ -312,7 +337,7 @@ function! javacomplete#imports#Add(...)
         let userinput = -1
       endif
       redraw!
-      
+
       if userinput < 0 || userinput >= len(result)
         echo "JavaComplete: wrong input"
       else

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -301,11 +301,7 @@ if !exists('s:RegularClassesDict')
 endif
 
 function! s:SortImportsList(importsList, ...)
-  if a:0 > 0
-    let sortType = a:1
-  else
-    let sortType = g:JavaComplete_ImportSortType
-  endif
+  let sortType = a:0 > 0 ? a:1 : g:JavaComplete_ImportSortType
   let importsListSorted = []
   if sortType == 'packageName'
     for a in g:JavaComplete_ImportOrder

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -300,9 +300,14 @@ if !exists('s:RegularClassesDict')
   let s:RegularClassesDict = javacomplete#util#GetRegularClassesDict(g:JavaComplete_RegularClasses)
 endif
 
-function! s:SortImportsList(importsList)
+function! s:SortImportsList(importsList, ...)
+  if a:0 > 0
+    let sortType = a:1
+  else
+    let sortType = g:JavaComplete_ImportSortType
+  endif
   let importsListSorted = []
-  if g:JavaComplete_ImportSortType == 'packageName'
+  if sortType == 'packageName'
     for a in g:JavaComplete_ImportOrder
       let l_a = filter(copy(a:importsList),"v:val =~? '^" . substitute(a, '\.', '\\.', 'g') . "'")
       if len(l_a) > 0
@@ -397,7 +402,7 @@ function! s:ChooseImportOption(options, classname)
 
   else
     call sort(options, 's:_SortStaticToEnd')
-    let options = s:SortImportsList(options)
+    let options = s:SortImportsList(options, 'packageName')
     let index = 0
     let message = ''
     for imp in options

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -263,6 +263,19 @@ function! s:AddImport(import)
     let insertline = insertline - 1
     let newline = 1
   else
+    let replaceIdx = -1
+    let idx = 0
+    for i in imports
+      if split(i[0], '\.')[-1] == className
+        let replaceIdx = idx
+        break
+      endif
+      let idx += 1
+    endfor
+    if replaceIdx > 0
+      silent execute imports[replaceIdx][1]. 'normal! cc'
+      call remove(imports, replaceIdx)
+    endif
     let insertline = imports[len(imports) - 1][1]
     let newline = 0
   endif

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -336,7 +336,7 @@ function! javacomplete#imports#Add(...)
   if classname =~ '^@.*'
     let classname = classname[1:]
   endif
-  if index(keys(s:RegularClassesDict), classname) < 0
+  if index(keys(s:RegularClassesDict), classname) < 0 || (len(a:0) >= 2 && a:2)
     let response = javacomplete#server#Communicate("-class-packages", classname, 'Filter packages to add import')
     if response =~ '^['
       let result = eval(response)
@@ -357,8 +357,8 @@ function! javacomplete#imports#Add(...)
             let message .= "\n"
           else
             let message .= "candidate [". index. "]: ". imp. "\n"
-            let index += 1
           endif
+          let index += 1
         endfor
         let message .= "\nselect one candidate [". g:JavaComplete_ImportDefault."]: "
         let userinput = input(message, '')
@@ -375,6 +375,7 @@ function! javacomplete#imports#Add(...)
           echo "JavaComplete: wrong input"
         else
           let import = result[userinput]
+          let s:RegularClassesDict[classname] = import
         endif
       endif
 

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -1,5 +1,5 @@
 " Vim completion script for java
-" Maintainer:   artur shaik <ashaihullin@gmail.com>
+" Maintainer: artur shaik <ashaihullin@gmail.com>
 "
 " Everything to work with imports
 
@@ -80,9 +80,9 @@ endfunction
 function! javacomplete#imports#GetImports(kind, ...)
   let filekey = a:0 > 0 && !empty(a:1) ? a:1 : javacomplete#GetCurrentFileKey()
   let props = get(g:JavaComplete_Files, filekey, {})
-  let props['imports']  = filekey == javacomplete#GetCurrentFileKey() ? s:GenerateImports() : props.unit.imports
-  let props['imports_static']   = []
-  let props['imports_fqn']  = []
+  let props['imports'] = filekey == javacomplete#GetCurrentFileKey() ? s:GenerateImports() : props.unit.imports
+  let props['imports_static'] = []
+  let props['imports_fqn'] = []
   let props['imports_star'] = ['java.lang.']
   if &ft == 'jsp' || filekey =~ '\.jsp$'
     let props.imports_star += ['javax.servlet.', 'javax.servlet.http.', 'javax.servlet.jsp.']
@@ -127,10 +127,10 @@ endfu
 " return [types, methods, fields]
 function! javacomplete#imports#SearchStaticImports(name, fullmatch)
   let result = [[], [], []]
-  let candidates = []       " list of the canonical name
+  let candidates = [] " list of the canonical name
   for item in javacomplete#imports#GetImports('imports_static')
     call javacomplete#logger#Log(item)
-    if item[-1:] == '*'     " static import on demand
+    if item[-1:] == '*' " static import on demand
       call add(candidates, item[:-3])
     elseif item[strridx(item, '.')+1:] ==# a:name
           \ || (!a:fullmatch && item[strridx(item, '.')+1:] =~ '^' . a:name)
@@ -183,28 +183,28 @@ function! s:SortImports()
     endfor
 
     call sort(importsList)
-    let importsList_sorted = []
+    let importsListSorted = []
     for a in g:JavaComplete_ImportOrder
       let l_a = filter(copy(importsList),"v:val =~? '^" . substitute(a, '\.', '\\.', 'g') . "'")
       if len(l_a) > 0
         for imp in l_a
           call remove(importsList, index(importsList, imp))
-          call add(importsList_sorted, imp)
+          call add(importsListSorted, imp)
         endfor
-        call add(importsList_sorted, '')
+        call add(importsListSorted, '')
       endif
     endfor
     if len(importsList) > 0
       for imp in importsList
-        call add(importsList_sorted, imp)
+        call add(importsListSorted, imp)
       endfor
-    elseif len(importsList_sorted) > 0
-      call remove(importsList_sorted, -1)
+    elseif len(importsListSorted) > 0
+      call remove(importsListSorted, -1)
     endif
 
     let saveCursor = getpos('.')
     silent execute beginLine.','.lastLine. 'delete _'
-    for imp in importsList_sorted
+    for imp in importsListSorted
       if imp != ''
         if &ft == 'jsp'
           call append(beginLine - 1, '<%@ page import = "'. imp. '" %>')
@@ -320,7 +320,7 @@ function! javacomplete#imports#Add(...)
   if classname =~ '^@.*'
     let classname = classname[1:]
   endif
-  if index(keys(s:RegularClassesDict),classname) < 0
+  if index(keys(s:RegularClassesDict), classname) < 0
     let response = javacomplete#server#Communicate("-class-packages", classname, 'Filter packages to add import')
     if response =~ '^['
       let result = eval(response)
@@ -403,17 +403,15 @@ function! javacomplete#imports#AddMissing()
     let missing = eval(response)
     for import in missing
       if len(import) > 1
-        let flag = 0
+        let isRegular = 0
         for class in import
           if index(g:JavaComplete_RegularClasses, class) >= 0
-            let flag = 1
-          endif
-          if flag
+            let isRegular = 1
             call s:AddImport(class)
             break
           endif
         endfor
-        if !flag
+        if !isRegular
           let message = join(map(range(len(import)), '"candidate [".v:val."]: ".import[v:val]'), "\n")
           let message .= "\nselect one candidate [". g:JavaComplete_ImportDefault."]: "
           let userinput = input(message, '')

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -357,7 +357,7 @@ function! s:ChooseImportOption(options, classname)
   let import = ''
   let options = a:options
   if len(options) == 0
-    echo "JavaComplete: classname '". classname. "' not found in any scope."
+    echo "JavaComplete: classname '". a:classname. "' not found in any scope."
 
   elseif len(options) == 1
     let import = options[0]

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -403,10 +403,15 @@ function! s:ChooseImportOption(options, classname)
       echo "JavaComplete: wrong input"
     else
       let import = options[userinput]
-      let s:RegularClassesDict[a:classname] = import
+      call s:PopulateRegularClasses(a:classname, import)
     endif
   endif
   return import
+endfunction
+
+function! s:PopulateRegularClasses(classname, import)
+    let s:RegularClassesDict[a:classname] = a:import
+    call javacomplete#util#SaveRegularClassesList(s:RegularClassesDict)
 endfunction
 
 function! javacomplete#imports#RemoveUnused()

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -185,7 +185,7 @@ function! s:SortImports()
     call sort(importsList)
     let importsList_sorted = []
     for a in g:JavaComplete_ImportOrder
-      let l_a = filter(copy(importsList),"v:val =~? '^" . a . "\\.'")
+      let l_a = filter(copy(importsList),"v:val =~? '^" . substitute(a, '\.', '\\.', 'g') . "'")
       if len(l_a) > 0
         for imp in l_a
           call remove(importsList, index(importsList, imp))

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -336,7 +336,7 @@ function! javacomplete#imports#Add(...)
   if classname =~ '^@.*'
     let classname = classname[1:]
   endif
-  if index(keys(s:RegularClassesDict), classname) < 0 || (len(a:0) >= 2 && a:2)
+  if a:0 == 0 || !a:1 || index(keys(s:RegularClassesDict), classname) < 0
     let response = javacomplete#server#Communicate("-class-packages", classname, 'Filter packages to add import')
     if response =~ '^['
       let result = eval(response)
@@ -387,14 +387,6 @@ function! javacomplete#imports#Add(...)
   else
     call s:AddImport(s:RegularClassesDict[classname])
     call s:SortImports()
-  endif
-
-
-  if a:0 > 0 && a:1
-    let cur = getpos('.')
-    let cur[2] = cur[2] + 1
-    execute 'startinsert'
-    call setpos('.', cur)
   endif
 endfunction
 

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -187,7 +187,7 @@ function! s:SortImports()
     "call s:sort(importsList)
     let importsList_sorted = []
     for a in g:JavaComplete_ImportOrder
-      let l_a = filter(copy(importsList),'v:val =~? "^' . a . '\\."')
+      let l_a = filter(copy(importsList),"v:val =~? '^" . a . "\\.'")
       if len(l_a) > 0
         for imp in l_a
           call remove(importsList, index(importsList, imp))

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -196,10 +196,10 @@ function! s:SortImports()
         endif
       else
         call append(beginLine - 1, '')
-        let saveCursor[1] += 1
       endif
       let beginLine += 1
     endfor
+    let saveCursor[1] += beginLine - lastLine - 1
     call setpos('.', saveCursor)
   endif
 endfunction

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -296,7 +296,7 @@ function! s:AddImport(import)
 
 endfunction
 
-if !exists('s:RegularClassesDict')
+if !exists('s:RegularClassesDict') && exists('g:JavaComplete_RegularClasses')
   let s:RegularClassesDict = javacomplete#util#GetRegularClassesDict(g:JavaComplete_RegularClasses)
 endif
 

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -213,6 +213,7 @@ function! s:SortImports()
         endif
       else
         call append(beginLine - 1, '')
+        let saveCursor[1] += 1
       endif
       let beginLine += 1
     endfor

--- a/autoload/javacomplete/server.vim
+++ b/autoload/javacomplete/server.vim
@@ -10,25 +10,6 @@ function! s:System(cmd, caller)
   return res
 endfunction
 
-if exists('*uniq')
-  function! s:_uniq(list) abort
-    return uniq(a:list)
-  endfunction
-else
-  function! s:_uniq(list) abort
-    let i = len(a:list) - 1
-    while 0 < i
-      if a:list[i] ==# a:list[i - 1]
-        call remove(a:list, i)
-        let i -= 2
-      else
-        let i -= 1
-      endif
-    endwhile
-    return a:list
-  endfunction
-endif
-
 function! s:Poll()
   let value = 0
 JavacompletePy << EOPC
@@ -240,7 +221,7 @@ endfunction
 
 function! s:ExpandAllPaths(path)
     let result = ''
-    let list = s:_uniq(sort(split(a:path, g:PATH_SEP)))
+    let list = javacomplete#util#uniq(sort(split(a:path, g:PATH_SEP)))
     for l in list
       let result = result. substitute(expand(l), '\\', '/', 'g') . g:PATH_SEP
     endfor

--- a/autoload/javacomplete/util.vim
+++ b/autoload/javacomplete/util.vim
@@ -248,6 +248,25 @@ function! javacomplete#util#RemoveFile(file)
   silent redraw!
 endfunction
 
+if exists('*uniq')
+  function! javacomplete#util#uniq(list) abort
+    return uniq(a:list)
+  endfunction
+else
+  function! javacomplete#util#uniq(list) abort
+    let i = len(a:list) - 1
+    while 0 < i
+      if a:list[i] ==# a:list[i - 1]
+        call remove(a:list, i)
+        let i -= 2
+      else
+        let i -= 1
+      endif
+    endwhile
+    return a:list
+  endfunction
+endif
+
 function! javacomplete#util#GetBase(extra)
   let base = expand(g:JavaComplete_BaseDir. g:FILE_SEP. "javacomplete2". g:FILE_SEP. a:extra)
   if !isdirectory(base)
@@ -258,12 +277,23 @@ function! javacomplete#util#GetBase(extra)
 endfunction
 
 function! javacomplete#util#GetRegularClassesDict(classes)
+  let path = javacomplete#util#GetBase('cache'). g:FILE_SEP. 'regular_classes_'. g:JavaComplete_ProjectKey. '.dat'
+  if filereadable(path)
+    let classes = readfile(path)
+  else
+    let classes = []
+  endif
+  let classes = javacomplete#util#uniq(sort(extend(classes, a:classes)))
   let dict = {}
-  for class in a:classes
+  for class in classes
     call extend(dict, {split(class,'\.')[-1] : class})
   endfor
   return dict
 endfunction
 
+function! javacomplete#util#SaveRegularClassesList(classesDict)
+    let path = javacomplete#util#GetBase('cache'). g:FILE_SEP. 'regular_classes_'. g:JavaComplete_ProjectKey. '.dat'
+    call writefile(values(a:classesDict), path)
+endfunction
 
 " vim:set fdm=marker sw=2 nowrap:

--- a/doc/javacomplete.txt
+++ b/doc/javacomplete.txt
@@ -46,7 +46,8 @@ javaparser library and javacomplete.txt.
 - Complete class name;
 - Add import statement for a given class name;
 - Complete methods declaration after '@Override';
-- Support for maven, gradle and Eclipse's '.classpath'.
+- Support for maven, gradle and Eclipse's '.classpath';
+- Cross-session cache.
 
 1.2 Requirements				*javacomplete-requirements*
 
@@ -70,20 +71,25 @@ You can download the lastest version from this url:
     autocmd Filetype java setlocal omnifunc=javacomplete#Complete
 
 3. Map keys you prefer:
-For insert class import with <F4>:
+For smart (trying to guess import option) insert class import with <F4>:
 
-    nmap <F4> <Plug>(JavaComplete-Imports-Add)
-    imap <F4> <Plug>(JavaComplete-Imports-Add)
+    nmap <F4> <Plug>(JavaComplete-Imports-AddSmart)
+    imap <F4> <Plug>(JavaComplete-Imports-AddSmart)
 
-For add all missing imports with <F5>:
+For usual (will ask for import option) insert class import with <F5>:
 
-    nmap <F5> <Plug>(JavaComplete-Imports-AddMissing)
-    imap <F5> <Plug>(JavaComplete-Imports-AddMissing)
+    nmap <F5> <Plug>(JavaComplete-Imports-Add)
+    imap <F5> <Plug>(JavaComplete-Imports-Add)
 
-For remove all missing imports with <F6>:
+For add all missing imports with <F6>:
 
-    nmap <F6> <Plug>(JavaComplete-Imports-RemoveUnused)
-    imap <F6> <Plug>(JavaComplete-Imports-RemoveUnused)
+    nmap <F6> <Plug>(JavaComplete-Imports-AddMissing)
+    imap <F6> <Plug>(JavaComplete-Imports-AddMissing)
+
+For remove all missing imports with <F7>:
+
+    nmap <F7> <Plug>(JavaComplete-Imports-RemoveUnused)
+    imap <F7> <Plug>(JavaComplete-Imports-RemoveUnused)
 
 4. Javavi library will be automatcally compiled when you
 use first time. 
@@ -243,12 +249,27 @@ A single letter indicates the kind of compeltion item. These kinds are:
 
         let g:JavaComplete_GradleExecutable = 'gradle'
 
+    Imports sorting type:
+
+        let g:JavaComplete_ImportSortType = 'jarName'
+        Sorting can by jar archives `jarName` or by package names `packageName`.
+
+    Specifies the order of import groups, when use `packageName` sorting type:
+
+        let g:JavaComplete_ImportOrder = ['java.', 'javax.', 'com.', 'org.', 'net.'] 
+        An import group is a list of individual import statements that all start with the same beginning of package name surrounded by blank lines above and below the group.
+
+    Regular class names that will be used automatically when you insert import:
+
+        let g:JavaComplete_RegularClasses = ['java.lang.String', 'java.lang.Object']
+        You can populate it with your custom classes, or it will be populated automatically when you choose any import option. List will be persisted, so it will be used next time you run the same project.
+
 2.4 Commands					*javacomplete-commands*
 
     JCimportsAddMissing - add all missing 'imports';
     JCimportsRemoveUnused - remove all unsused 'imports';
     JCimportAdd - add 'import' for classname that is under cursor, or before it;
-    JCimportAddI - the same, but enable insert mode after 'import' was added;
+    JCimportAddSmart - add 'import' for classname trying to guess variant without ask user to choose an option (it will ask on false guessing);
     
     JCserverShowPort - show port, through which vim plugin communicates with server;
     JCserverShowPID - show server process identificator;

--- a/libs/javavi/src/main/java/kg/ash/javavi/Javavi.java
+++ b/libs/javavi/src/main/java/kg/ash/javavi/Javavi.java
@@ -8,7 +8,7 @@ import kg.ash.javavi.clazz.SourceClass;
 
 public class Javavi {
 
-    static final String VERSION	= "2.3.4.2";
+    static final String VERSION	= "2.3.5";
 
     public static String NEWLINE = "";
 

--- a/libs/javavi/src/main/java/kg/ash/javavi/actions/ActionFactory.java
+++ b/libs/javavi/src/main/java/kg/ash/javavi/actions/ActionFactory.java
@@ -28,6 +28,8 @@ public class ActionFactory {
                 return new ClassRecompileAction();
             case "-collect-packages":
                 return new CollectPackagesAction();
+            case "-fetch-class-archives":
+                return new GetClassesArchiveNamesAction();
         }
 
         return null;

--- a/libs/javavi/src/main/java/kg/ash/javavi/actions/ActionWithTarget.java
+++ b/libs/javavi/src/main/java/kg/ash/javavi/actions/ActionWithTarget.java
@@ -18,7 +18,11 @@ public abstract class ActionWithTarget implements Action {
     }
 
     protected String parseTarget(String[] args) {
-        return targetParser.parse(args[args.length - 1]);
+        if (args.length > 0) {
+            return targetParser.parse(args[args.length - 1]);
+        } else {
+            return "";
+        }
     }
     
 }

--- a/libs/javavi/src/main/java/kg/ash/javavi/actions/GetClassesArchiveNamesAction.java
+++ b/libs/javavi/src/main/java/kg/ash/javavi/actions/GetClassesArchiveNamesAction.java
@@ -1,0 +1,82 @@
+package kg.ash.javavi.actions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import kg.ash.javavi.Javavi;
+import kg.ash.javavi.cache.Cache;
+import kg.ash.javavi.searchers.JavaClassMap;
+
+public class GetClassesArchiveNamesAction extends ActionWithTarget {
+
+    @Override
+    public String perform(String[] string) {
+        String classes = parseTarget(string);
+
+        Map<String, List<String>> result = new HashMap<>();
+        for (String _classFqn : classes.split(",")) {
+            final String classFqn = removeStaticKeyword(_classFqn);
+
+            String[] classFqnArray = classFqn.split("\\.");
+            String className = classFqnArray[classFqnArray.length - 1];
+
+            Javavi.debug(className);
+
+            HashMap<String, JavaClassMap> classPackages = getClassPackages();
+            if (classPackages.containsKey(className)) {
+                String classPackage = removeLastElementAndJoin(classFqnArray);
+
+                Javavi.debug(classPackage);
+                
+                JavaClassMap cm = classPackages.get(className);
+                Arrays.stream(new String[]{"", "$"}).forEach(s -> {
+                    if (cm.getSubpackages().get(classPackage + s) != null) {
+                        String fileName = cm.getSubpackages().get(classPackage + s);
+                        if (result.containsKey(fileName)) {
+                            result.get(fileName).add(classFqn);
+                        } else {
+                            result.put(fileName, new ArrayList(Arrays.asList(new String[]{classFqn})));
+                        }
+
+                        return;
+                    }
+                });
+            }
+
+        }
+
+        return String.format("[%s]", buildResult(result));
+    }
+
+    private String removeStaticKeyword(String classFqn) {
+            if (classFqn.contains(" ")) {
+                return classFqn.split(" ")[1];
+            }
+
+            return classFqn;
+    }
+
+    private HashMap<String, JavaClassMap> getClassPackages() {
+        return Cache.getInstance().getClassPackages();
+    }
+
+    private String removeLastElementAndJoin(String[] array) {
+        String[] newArray = new String[array.length - 1];
+        System.arraycopy(array, 0, newArray, 0, newArray.length);
+        return String.join(".", newArray);
+    }
+
+    private StringBuilder buildResult(Map<String, List<String>> result) {
+        StringBuilder builder = new StringBuilder();
+        result.forEach((s, l) -> {
+            builder.append("['").append(s).append("',[");
+            l.forEach(classFqn -> builder.append("'").append(classFqn).append("',"));
+            builder.append("]],");
+        });
+
+        return builder;
+    }
+    
+}

--- a/libs/javavi/src/main/java/kg/ash/javavi/output/OutputClassPackages.java
+++ b/libs/javavi/src/main/java/kg/ash/javavi/output/OutputClassPackages.java
@@ -27,7 +27,7 @@ public class OutputClassPackages {
         if (classPackages.containsKey(targetClass)) {
             JavaClassMap cm = classPackages.get(targetClass);
             if (cm.getType() == JavaClassMap.TYPE_CLASS) {
-                cm.getSubpackages().forEach((String scope) -> {
+                cm.getSubpackages().keySet().forEach((String scope) -> {
                     if (scope.endsWith("$")) {
                         String target = scope + targetClass;
                         ClassSearcher seacher = new ClassSearcher();

--- a/libs/javavi/src/main/java/kg/ash/javavi/output/OutputSimilar.java
+++ b/libs/javavi/src/main/java/kg/ash/javavi/output/OutputSimilar.java
@@ -24,7 +24,8 @@ public abstract class OutputSimilar {
             return Cache.PACKAGES_EMPTY_ERROR;
         }
 
-        List<String> keys = sort(getKeys(target));
+        List<String> keys = getKeys(target);
+        Collections.sort(keys);
 
         StringBuilder builder = new StringBuilder();
         for (String key : keys) {
@@ -40,19 +41,6 @@ public abstract class OutputSimilar {
         return String.format("[%s]", builder);
     }
 
-    private List<String> sort(List<String> keys) {
-        Collections.sort(keys, (String s1, String s2) -> {
-            int i1 = s1.length(); int i2 = s2.length();
-            if (i1 < i2) return -1;
-            if (i1 == i2) {
-                return s1.compareTo(s2);
-            }
-            return 1;
-        });
-
-        return keys;
-    }
-    
     protected abstract List<String> getKeys(String target);
 
 }

--- a/libs/javavi/src/main/java/kg/ash/javavi/searchers/ClasspathPackageSearcher.java
+++ b/libs/javavi/src/main/java/kg/ash/javavi/searchers/ClasspathPackageSearcher.java
@@ -53,7 +53,7 @@ public class ClasspathPackageSearcher implements PackageSeacherIFace {
                     try {
                         for (Enumeration entries = new ZipFile(filePath).entries(); entries.hasMoreElements(); ) {
                             String entry = entries.nextElement().toString();
-                            result.add(new PackageEntry(entry, JavaClassMap.SOURCETYPE_CLASSPATH));
+                            result.add(new PackageEntry(entry, JavaClassMap.SOURCETYPE_CLASSPATH, filePath));
                         }
                     } catch (Exception e) {
                         Javavi.debug(e);

--- a/libs/javavi/src/main/java/kg/ash/javavi/searchers/JavaClassMap.java
+++ b/libs/javavi/src/main/java/kg/ash/javavi/searchers/JavaClassMap.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public abstract class JavaClassMap implements Serializable {
@@ -18,7 +19,7 @@ public abstract class JavaClassMap implements Serializable {
     protected String name = null;
     protected HashMap<String, Integer> pathsMap = new HashMap<>();
     protected List<String> classes = new ArrayList<>();
-    protected List<String> subpackages = new ArrayList<>();
+    protected Map<String, String> subpackages = new HashMap<>();
 
     public JavaClassMap(String name) {
         setName(name);
@@ -44,13 +45,13 @@ public abstract class JavaClassMap implements Serializable {
 		this.name = name;
 	}
 
-    public void add(String path, int source, int type) {
+    public void add(String path, int source, int type, String filename) {
         if (!contains(path)) {
             pathsMap.put(path, source);
             if (type == TYPE_CLASS) {
                 classes.add(path);
             } else {
-                subpackages.add(path);
+                subpackages.put(path, filename);
             }
         }
     }
@@ -63,7 +64,7 @@ public abstract class JavaClassMap implements Serializable {
 
     public StringBuilder getCachedSubpackages() {
         StringBuilder cachedSubpackages = new StringBuilder();
-        subpackages.stream().sorted().forEach(path -> cachedSubpackages.append("'").append(path).append("',"));
+        subpackages.keySet().stream().sorted().forEach(path -> cachedSubpackages.append("'").append(path).append("',"));
         return cachedSubpackages;
     }
 
@@ -72,7 +73,7 @@ public abstract class JavaClassMap implements Serializable {
         return classes;
     }
 
-    public List<String> getSubpackages() {
+    public Map<String, String> getSubpackages() {
         return subpackages;
     }
 

--- a/libs/javavi/src/main/java/kg/ash/javavi/searchers/PackageEntry.java
+++ b/libs/javavi/src/main/java/kg/ash/javavi/searchers/PackageEntry.java
@@ -9,10 +9,17 @@ public class PackageEntry {
     private int source;
     private String javaFile = null;
     private String classFile = null;
+    private String archiveName = null;
 
     public PackageEntry(String entry, int source) {
         this.entry = entry;
         this.source = source;
+    }
+
+    public PackageEntry(String entry, int source, String archiveName) {
+        this.entry = entry;
+        this.source = source;
+        this.archiveName = archiveName;
     }
 
     public PackageEntry(String entry, int source, String filePath, int fileType) {
@@ -47,6 +54,14 @@ public class PackageEntry {
 
     public void setClassFile(String classFile) {
         this.classFile = classFile;
+    }
+
+    public void setArchiveName(String archiveName) {
+        this.archiveName = archiveName;
+    }
+
+    public String getArchiveName() {
+        return archiveName;
     }
 
     @Override

--- a/libs/javavi/src/main/java/kg/ash/javavi/searchers/PackagesLoader.java
+++ b/libs/javavi/src/main/java/kg/ash/javavi/searchers/PackagesLoader.java
@@ -1,6 +1,5 @@
 package kg.ash.javavi.searchers;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -73,7 +72,7 @@ public class PackagesLoader {
 
         if (!child.isEmpty() && !parentDots.isEmpty()) {
             ClassNameMap classMap = (ClassNameMap) getClassMap(child, JavaClassMap.TYPE_CLASS);
-            classMap.add(parentDots, source, JavaClassMap.TYPE_SUBPACKAGE);
+            classMap.add(parentDots, source, JavaClassMap.TYPE_SUBPACKAGE, entry.getArchiveName());
             if (entry.getJavaFile() != null) {
                 classMap.setJavaFile(entry.getJavaFile());
             } 
@@ -83,7 +82,7 @@ public class PackagesLoader {
 
             if (!nested) {
                 getClassMap(parentDots, JavaClassMap.TYPE_SUBPACKAGE)
-                    .add(child, source, JavaClassMap.TYPE_CLASS);
+                    .add(child, source, JavaClassMap.TYPE_CLASS, null);
             }
 
             addToParent(parent, source);
@@ -104,7 +103,7 @@ public class PackagesLoader {
         String child = name.substring(seppos + 1);
 
         getClassMap(makeDots(parent), JavaClassMap.TYPE_SUBPACKAGE)
-            .add(child, source, JavaClassMap.TYPE_SUBPACKAGE);
+            .add(child, source, JavaClassMap.TYPE_SUBPACKAGE, null);
 
         addToParent(parent, source);
     }

--- a/libs/javavi/src/main/java/kg/ash/javavi/searchers/SourcePackageSearcher.java
+++ b/libs/javavi/src/main/java/kg/ash/javavi/searchers/SourcePackageSearcher.java
@@ -15,12 +15,14 @@ import kg.ash.javavi.Javavi;
 
 public class SourcePackageSearcher implements PackageSeacherIFace {
 
-    private String sourceDirectories;
+    private String sourceDirectories = "";
     private ByExtensionVisitor finder = 
         new ByExtensionVisitor(Arrays.asList("*.java"));
 
     public SourcePackageSearcher(String sourceDirectories) {
-        this.sourceDirectories = sourceDirectories;
+        if (sourceDirectories != null) {
+            this.sourceDirectories = sourceDirectories;
+        }
     }
     
     public List<PackageEntry> loadEntries() {

--- a/libs/javavi/src/test/java/kg/ash/javavi/actions/GetClassesArchiveNamesActionTest.java
+++ b/libs/javavi/src/test/java/kg/ash/javavi/actions/GetClassesArchiveNamesActionTest.java
@@ -1,0 +1,80 @@
+package kg.ash.javavi.actions;
+
+import java.util.HashMap;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import kg.ash.javavi.searchers.ClassNameMap;
+import kg.ash.javavi.searchers.JavaClassMap;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.integration.junit4.JMockit;
+
+@RunWith(JMockit.class)
+public class GetClassesArchiveNamesActionTest {
+
+    @Test
+    public void testArchiveNamesFetch() {
+        new MockUp<GetClassesArchiveNamesAction>() {
+            @Mock
+            private HashMap<String, JavaClassMap> getClassPackages() {
+                HashMap<String, JavaClassMap> map = new HashMap<>();
+                JavaClassMap jc = new ClassNameMap("List");
+                jc.add("java.util", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE, "/dir/lib.jar");
+                map.put("List", jc);
+                jc = new ClassNameMap("HashMap");
+                jc.add("java.util", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE, "/dir/lib.jar");
+                map.put("HashMap", jc);
+                return map;
+            }
+        };
+        
+        GetClassesArchiveNamesAction action = new GetClassesArchiveNamesAction();
+        String result = action.perform(new String[]{"java.util.List,java.util.HashMap"});
+        Assert.assertEquals("[['/dir/lib.jar',['java.util.List','java.util.HashMap',]],]", result);
+    }
+
+    @Test
+    public void testNoResult() {
+        new MockUp<GetClassesArchiveNamesAction>() {
+            @Mock
+            private HashMap<String, JavaClassMap> getClassPackages() {
+                return new HashMap<>();
+            }
+        };
+        
+        GetClassesArchiveNamesAction action = new GetClassesArchiveNamesAction();
+        String result = action.perform(new String[]{"java.util.List,java.util.HashMap"});
+        Assert.assertEquals("[]", result);
+    }
+
+    @Test
+    public void testEmptyRequest() {
+        new MockUp<GetClassesArchiveNamesAction>() {
+            @Mock
+            private HashMap<String, JavaClassMap> getClassPackages() {
+                return new HashMap<>();
+            }
+        };
+        
+        GetClassesArchiveNamesAction action = new GetClassesArchiveNamesAction();
+        String result = action.perform(new String[]{""});
+        Assert.assertEquals("[]", result);
+    }
+
+    @Test
+    public void testNoArgs() {
+        new MockUp<GetClassesArchiveNamesAction>() {
+            @Mock
+            private HashMap<String, JavaClassMap> getClassPackages() {
+                return new HashMap<>();
+            }
+        };
+        
+        GetClassesArchiveNamesAction action = new GetClassesArchiveNamesAction();
+        String result = action.perform(new String[0]);
+        Assert.assertEquals("[]", result);
+    }
+}

--- a/libs/javavi/src/test/java/kg/ash/javavi/output/OutputClassPackagesTest.java
+++ b/libs/javavi/src/test/java/kg/ash/javavi/output/OutputClassPackagesTest.java
@@ -18,8 +18,8 @@ public class OutputClassPackagesTest {
     public void Init() {
         Javavi.system.put("sources", "");
         JavaClassMap classMap = new ClassNameMap(target);
-        classMap.add("bar.baz", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE);
-        classMap.add("foo.bar", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE);
+        classMap.add("bar.baz", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE, null);
+        classMap.add("foo.bar", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE, null);
 
         classPackages = new HashMap<>();
         classPackages.put(target, classMap);
@@ -27,7 +27,7 @@ public class OutputClassPackagesTest {
 
     @Test
     public void testCorrect() {
-        Assert.assertEquals("['bar.baz.Bar','foo.bar.Bar',]", new OutputClassPackages(classPackages).get(target));
+        Assert.assertEquals("['foo.bar.Bar','bar.baz.Bar',]", new OutputClassPackages(classPackages).get(target));
     }
 
     @Test

--- a/libs/javavi/src/test/java/kg/ash/javavi/output/OutputPackageInfoTest.java
+++ b/libs/javavi/src/test/java/kg/ash/javavi/output/OutputPackageInfoTest.java
@@ -16,9 +16,9 @@ public class OutputPackageInfoTest {
     @Before
     public void Init() {
         JavaClassMap classMap = new ClassNameMap(target);
-        classMap.add("baz", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE);
-        classMap.add("bax", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE);
-        classMap.add("Bat", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_CLASS);
+        classMap.add("baz", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE, null);
+        classMap.add("bax", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE, null);
+        classMap.add("Bat", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_CLASS, null);
 
         classPackages = new HashMap<>();
         classPackages.put(target, classMap);

--- a/libs/javavi/src/test/java/kg/ash/javavi/output/OutputSimilarClassesTest.java
+++ b/libs/javavi/src/test/java/kg/ash/javavi/output/OutputSimilarClassesTest.java
@@ -18,19 +18,19 @@ public class OutputSimilarClassesTest {
         classPackages = new HashMap<>();
 
         JavaClassMap classMap = new ClassNameMap("Barabaz");
-        classMap.add("bar", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE);
+        classMap.add("bar", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE, null);
         classPackages.put("Barabaz", classMap);
 
         classMap = new ClassNameMap("Bara");
-        classMap.add("bar.bara", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE);
+        classMap.add("bar.bara", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE, null);
         classPackages.put("Bara", classMap);
 
         classMap = new ClassNameMap("Bazaraz");
-        classMap.add("bar.baz", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE);
+        classMap.add("bar.baz", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE, null);
         classPackages.put("Bazaraz", classMap);
 
         classMap = new ClassNameMap("Foobar");
-        classMap.add("bar.bas", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE);
+        classMap.add("bar.bas", JavaClassMap.SOURCETYPE_CLASSPATH, JavaClassMap.TYPE_SUBPACKAGE, null);
         classPackages.put("Foobar", classMap);
     }
     

--- a/plugin/javacomplete.vim
+++ b/plugin/javacomplete.vim
@@ -33,10 +33,10 @@ let g:JavaComplete_ClasspathGenerationOrder =
       \ get(g:, 'g:JavaComplete_ClasspathGenerationOrder', ['Eclipse', 'Maven', 'Gradle'])
 
 let g:JavaComplete_ImportOrder =
-      \ get(g:, 'JavaComplete_ImportOrder',['java.', 'javax.', 'com.', 'org.', 'net.'])
+      \ get(g:, 'JavaComplete_ImportOrder', ['java.', 'javax.', 'com.', 'org.', 'net.'])
 
 let g:JavaComplete_RegularClasses =
-      \ get(g:, 'JavaComplete_RegularClasses',['java.lang.String','java.lang.Object'])
+      \ get(g:, 'JavaComplete_RegularClasses', ['java.lang.String', 'java.lang.Object', 'java.lang.Exception', 'java.lang.StringBuilder', 'java.lang.Override', 'java.lang.UnsupportedOperationException', 'java.math.BigDecimal'])
 
 command! JCimportsAddMissing call javacomplete#imports#AddMissing()
 command! JCimportsRemoveUnused call javacomplete#imports#RemoveUnused()

--- a/plugin/javacomplete.vim
+++ b/plugin/javacomplete.vim
@@ -32,6 +32,9 @@ let g:JavaComplete_ShowExternalCommandsOutput =
 let g:JavaComplete_ClasspathGenerationOrder =
       \ get(g:, 'g:JavaComplete_ClasspathGenerationOrder', ['Eclipse', 'Maven', 'Gradle'])
 
+let g:JavaComplete_ImportOrder =
+      \ get(g:,'JavaComplete_ImportOrder',['java.', 'javax.', 'com.', 'org.', '.net'])
+
 command! JCimportsAddMissing call javacomplete#imports#AddMissing()
 command! JCimportsRemoveUnused call javacomplete#imports#RemoveUnused()
 command! JCimportAdd call javacomplete#imports#Add()

--- a/plugin/javacomplete.vim
+++ b/plugin/javacomplete.vim
@@ -36,7 +36,7 @@ let g:JavaComplete_ImportOrder =
       \ get(g:, 'JavaComplete_ImportOrder', ['java.', 'javax.', 'com.', 'org.', 'net.'])
 
 let g:JavaComplete_RegularClasses =
-      \ get(g:, 'JavaComplete_RegularClasses', ['java.lang.String', 'java.lang.Object', 'java.lang.Exception', 'java.lang.StringBuilder', 'java.lang.Override', 'java.lang.UnsupportedOperationException', 'java.math.BigDecimal', 'java.lang.Boolean'])
+      \ get(g:, 'JavaComplete_RegularClasses', ['java.lang.String', 'java.lang.Object', 'java.lang.Exception', 'java.lang.StringBuilder', 'java.lang.Override', 'java.lang.UnsupportedOperationException', 'java.math.BigDecimal', 'java.lang.Byte', 'java.lang.Short', 'java.lang.Integer', 'java.lang.Long', 'java.lang.Float', 'java.lang.Double', 'java.lang.Character', 'java.lang.Boolean'])
 
 command! JCimportsAddMissing call javacomplete#imports#AddMissing()
 command! JCimportsRemoveUnused call javacomplete#imports#RemoveUnused()

--- a/plugin/javacomplete.vim
+++ b/plugin/javacomplete.vim
@@ -33,10 +33,10 @@ let g:JavaComplete_ClasspathGenerationOrder =
       \ get(g:, 'g:JavaComplete_ClasspathGenerationOrder', ['Eclipse', 'Maven', 'Gradle'])
 
 let g:JavaComplete_ImportOrder =
-      \ get(g:,'JavaComplete_ImportOrder',['java.', 'javax.', 'com.', 'org.', 'net.'])
+      \ get(g:, 'JavaComplete_ImportOrder',['java.', 'javax.', 'com.', 'org.', 'net.'])
 
 let g:JavaComplete_RegularClasses =
-      \ get(g:,'JavaComplete_RegularClasses',['java.lang.String','java.lang.Object'])
+      \ get(g:, 'JavaComplete_RegularClasses',['java.lang.String','java.lang.Object'])
 
 command! JCimportsAddMissing call javacomplete#imports#AddMissing()
 command! JCimportsRemoveUnused call javacomplete#imports#RemoveUnused()

--- a/plugin/javacomplete.vim
+++ b/plugin/javacomplete.vim
@@ -40,8 +40,8 @@ let g:JavaComplete_RegularClasses =
 
 command! JCimportsAddMissing call javacomplete#imports#AddMissing()
 command! JCimportsRemoveUnused call javacomplete#imports#RemoveUnused()
+command! JCimportAddSmart call javacomplete#imports#Add(1)
 command! JCimportAdd call javacomplete#imports#Add()
-command! JCimportAddI call javacomplete#imports#Add(1)
 
 command! JCserverShowPort call javacomplete#server#ShowPort()
 command! JCserverShowPID call javacomplete#server#ShowPID()
@@ -68,7 +68,9 @@ inoremap <Plug>(JavaComplete-Imports-AddMissing) <c-r>=<SID>nop(javacomplete#imp
 nnoremap <Plug>(JavaComplete-Imports-RemoveUnused) :call javacomplete#imports#RemoveUnused()<cr>
 inoremap <Plug>(JavaComplete-Imports-RemoveUnused) <c-r>=<SID>nop(javacomplete#imports#RemoveUnused())<cr>
 nnoremap <Plug>(JavaComplete-Imports-Add) :call javacomplete#imports#Add()<cr>
+nnoremap <Plug>(JavaComplete-Imports-AddSmart) :call javacomplete#imports#Add(1)<cr>
 inoremap <Plug>(JavaComplete-Imports-Add) <c-r>=<SID>nop(javacomplete#imports#Add())<cr>
+inoremap <Plug>(JavaComplete-Imports-AddSmart) <c-r>=<SID>nop(javacomplete#imports#Add(1))<cr>
 
 
 

--- a/plugin/javacomplete.vim
+++ b/plugin/javacomplete.vim
@@ -32,6 +32,9 @@ let g:JavaComplete_ShowExternalCommandsOutput =
 let g:JavaComplete_ClasspathGenerationOrder =
       \ get(g:, 'g:JavaComplete_ClasspathGenerationOrder', ['Eclipse', 'Maven', 'Gradle'])
 
+let g:JavaComplete_ImportSortType =
+      \ get(g:, 'JavaComplete_ImportSortType', 'jarName')
+
 let g:JavaComplete_ImportOrder =
       \ get(g:, 'JavaComplete_ImportOrder', ['java.', 'javax.', 'com.', 'org.', 'net.'])
 

--- a/plugin/javacomplete.vim
+++ b/plugin/javacomplete.vim
@@ -33,7 +33,7 @@ let g:JavaComplete_ClasspathGenerationOrder =
       \ get(g:, 'g:JavaComplete_ClasspathGenerationOrder', ['Eclipse', 'Maven', 'Gradle'])
 
 let g:JavaComplete_ImportOrder =
-      \ get(g:,'JavaComplete_ImportOrder',['java', 'javax', 'com', 'org', 'net'])
+      \ get(g:,'JavaComplete_ImportOrder',['java.', 'javax.', 'com.', 'org.', 'net.'])
 
 command! JCimportsAddMissing call javacomplete#imports#AddMissing()
 command! JCimportsRemoveUnused call javacomplete#imports#RemoveUnused()

--- a/plugin/javacomplete.vim
+++ b/plugin/javacomplete.vim
@@ -36,7 +36,7 @@ let g:JavaComplete_ImportOrder =
       \ get(g:, 'JavaComplete_ImportOrder', ['java.', 'javax.', 'com.', 'org.', 'net.'])
 
 let g:JavaComplete_RegularClasses =
-      \ get(g:, 'JavaComplete_RegularClasses', ['java.lang.String', 'java.lang.Object', 'java.lang.Exception', 'java.lang.StringBuilder', 'java.lang.Override', 'java.lang.UnsupportedOperationException', 'java.math.BigDecimal'])
+      \ get(g:, 'JavaComplete_RegularClasses', ['java.lang.String', 'java.lang.Object', 'java.lang.Exception', 'java.lang.StringBuilder', 'java.lang.Override', 'java.lang.UnsupportedOperationException', 'java.math.BigDecimal', 'java.lang.Boolean'])
 
 command! JCimportsAddMissing call javacomplete#imports#AddMissing()
 command! JCimportsRemoveUnused call javacomplete#imports#RemoveUnused()

--- a/plugin/javacomplete.vim
+++ b/plugin/javacomplete.vim
@@ -33,7 +33,7 @@ let g:JavaComplete_ClasspathGenerationOrder =
       \ get(g:, 'g:JavaComplete_ClasspathGenerationOrder', ['Eclipse', 'Maven', 'Gradle'])
 
 let g:JavaComplete_ImportOrder =
-      \ get(g:,'JavaComplete_ImportOrder',['java.', 'javax.', 'com.', 'org.', '.net'])
+      \ get(g:,'JavaComplete_ImportOrder',['java', 'javax', 'com', 'org', 'net'])
 
 command! JCimportsAddMissing call javacomplete#imports#AddMissing()
 command! JCimportsRemoveUnused call javacomplete#imports#RemoveUnused()

--- a/t/imports.vim
+++ b/t/imports.vim
@@ -1,4 +1,5 @@
 source autoload/javacomplete/imports.vim
+source plugin/javacomplete.vim
 source t/javacomplete.vim
 
 call vspec#hint({'sid': 'g:SID("imports")', 'scope': 'SScope()'})
@@ -19,7 +20,10 @@ describe 'javacomplete imports test'
         Expect getline(5) == 'import foo.bar.Baz;'
 
         call Call('s:AddImport', 'zoo.bar.Baz')
-        Expect getline(5) == 'import foo.bar.Baz;'
+        Expect getline(5) == 'import zoo.bar.Baz;'
+
+        call Call('s:AddImport', 'zoo.bar.Baz')
+        Expect getline(5) == 'import zoo.bar.Baz;'
 
         new
 
@@ -34,7 +38,7 @@ describe 'javacomplete imports test'
         Expect getline(3) == 'import foo.bar.Baz;'
 
         call Call('s:AddImport', 'zoo.bar.Baz')
-        Expect getline(3) == 'import foo.bar.Baz;'
+        Expect getline(3) == 'import zoo.bar.Baz;'
 
     end
 end


### PR DESCRIPTION
So, summary:

- sort by package names, based on `g:JavaComplete_ImportOrder` list;
- sort by jar archives;
- trying to guess import option, based on `g:JavaComplete_RegularClasses` list;
- persist choosed import options to insert them automatically next time (even if vim reloaded);
- replace import name if another import for the class already exists.