### PR TITLE
Fix warning message

### DIFF
--- a/autoload/javacomplete/classpath/maven.vim
+++ b/autoload/javacomplete/classpath/maven.vim
@@ -97,7 +97,7 @@ function! javacomplete#classpath#maven#BuildClasspathHandler(jobId, data, event)
     for data in filter(a:data,'v:val !~ "^\\s*$"')
       if g:JavaComplete_ShowExternalCommandsOutput
         echomsg data
-      elseif data =~ "^[ERROR]\w*"
+      elseif data =~ '^\[ERROR\]\w*' || data =~ '^\[WARNING\]\w*'
         echohl WarningMsg | echomsg data | echohl None
       endif
     endfor


### PR DESCRIPTION
print warning message even if g:JavaComplete_ShowExternalCommandsOutput = 1.
fix unnecessary warnings
close #226