### PR TITLE
Update doc for g:JavaComplete_UsePython3

### DIFF
--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -3,7 +3,7 @@
 
 " It doesn't make sense to do any work if vim doesn't support any Python since
 " we relly on it to properly work.
-if has("python") && get(g:, 'JavaComplete_UsePython3', 0) == 0
+if get(g:, 'JavaComplete_UsePython3', 0) == 0 && has('python')
   command! -nargs=1 JavacompletePy py <args>
   command! -nargs=1 JavacompletePyfile pyfile <args>
 elseif has("python3")

--- a/doc/javacomplete.txt
+++ b/doc/javacomplete.txt
@@ -273,6 +273,11 @@ A single letter indicates the kind of compeltion item. These kinds are:
         let g:JavaComplete_RegularClasses = ['java.lang.String', 'java.lang.Object']
         You can populate it with your custom classes, or it will be populated automatically when you choose any import option. List will be persisted, so it will be used next time you run the same project.
 
+    Make javacomplete2 use python3 interpreter instead of python2
+
+        let g:JavaComplete_UsePython3 = 1
+        an option to make javacomplete2 use python3 interpreter instead of python2, default value is 0.
+
 2.4 Commands					*javacomplete-commands*
 
     JCimportsAddMissing - add all missing 'imports';


### PR DESCRIPTION
1.  Update doc for g:JavaComplete_UsePython3
2.  Reverse the check to avoid needing to probe the python2 host