### PR TITLE
Remove doc tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,4 @@ libs/javavi/target/
 *.lock
 .vim-flavor
 
-doc/tags
-tags
-
 .vimrc


### PR DESCRIPTION
hi, I sent you a pull request adding these to `.gitignore`, but I wanna retract them. I think these should still not be committed into the repository, since every user should generate them if they desire to do so. Maybe add them to a global `.gitignore`, (`git config --global core.excludesfile ~/.gitignore_global`), so as to keep ignoring them in your own environment.