### PR TITLE
Fix for 234

### DIFF
--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -206,6 +206,7 @@ augroup javacomplete
   autocmd BufEnter *.java,*.jsp call s:SetCurrentFileKey()
   autocmd BufWritePost *.java call s:RemoveCurrentFromCache()
   autocmd VimLeave * call javacomplete#server#Terminate()
+	autocmd VimLeavePre * call javacomplete#server#Stop()
 
   if v:version > 704 || v:version == 704 && has('patch143')
     autocmd TextChangedI *.java,*.jsp call s:HandleTextChangedI()

--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -206,7 +206,7 @@ augroup javacomplete
   autocmd BufEnter *.java,*.jsp call s:SetCurrentFileKey()
   autocmd BufWritePost *.java call s:RemoveCurrentFromCache()
   autocmd VimLeave * call javacomplete#server#Terminate()
-	autocmd VimLeavePre * call javacomplete#server#Stop()
+  autocmd VimLeavePre * call javacomplete#server#Stop()
 
   if v:version > 704 || v:version == 704 && has('patch143')
     autocmd TextChangedI *.java,*.jsp call s:HandleTextChangedI()

--- a/autoload/javacomplete/server.vim
+++ b/autoload/javacomplete/server.vim
@@ -45,9 +45,9 @@ function! javacomplete#server#Terminate()
 endfunction
 
 function! javacomplete#server#Stop()
-	if s:Poll()
-		JavacompltePy vim.command('!kill %d'%(bridgeState.pid()+1))
-	endif
+  if s:Poll()
+    JavacompltePy vim.command('!kill %d'%(bridgeState.pid()+1))
+  endif
 endfunction
 
 function! javacomplete#server#Start()

--- a/autoload/javacomplete/server.vim
+++ b/autoload/javacomplete/server.vim
@@ -46,7 +46,7 @@ endfunction
 
 function! javacomplete#server#Stop()
 	if s:Poll()
-		JavacompltePy vim.command('!kill %d'%bridgeState.pid())
+		JavacompltePy vim.command('!kill %d'%(bridgeState.pid()+1))
 	endif
 endfunction
 

--- a/autoload/javacomplete/server.vim
+++ b/autoload/javacomplete/server.vim
@@ -44,6 +44,12 @@ function! javacomplete#server#Terminate()
   endif
 endfunction
 
+function! javacomplete#server#Stop()
+	if s:Poll()
+		JavacompltePy vim.command('!kill %d'%bridgeState.pid())
+	endif
+endfunction
+
 function! javacomplete#server#Start()
   if s:Poll() == 0 && s:serverStartBlocked == 0
     call s:Log("start server")


### PR DESCRIPTION
A fix for #234 

This adds the function javacomplete#server#Stop() which executes  `!kill <pid>` on VimLeavePre. This should terminate the server via SIGINT when vim is closed by the user. 

It will not work on windows yet, but it should be a decent start.