### PR TITLE
Support for Google style import ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Default mappings:
 
 `let g:JavaComplete_ImportSortType = 'jarName'` - imports sorting type. Sorting can be by jar archives `jarName` or by package names `packageName`.
 
-`let g:JavaComplete_ImportOrder = ['java.', 'javax.', 'com.', 'org.', 'net.']` - Specifies the order of import groups, when use `packageName` sorting type. An import group is a list of individual import statements that all start with the same beginning of package name surrounded by blank lines above and below the group.
+`let g:JavaComplete_ImportOrder = ['java.', 'javax.', 'com.', 'org.', 'net.']` - Specifies the order of import groups, when use `packageName` sorting type.  An import group is a list of individual import statements that all start with the same beginning of package name surrounded by blank lines above and below the group. A `*` indicates all packages not specified, for 'google style' import ordering, e.g. `let g:JavaComplete_ImportOrder = ['com.google.', *, 'java.', 'javax.']`
 
 `let g:JavaComplete_RegularClasses = ['java.lang.String', 'java.lang.Object']` - Regular class names that will be used automatically when you insert import. You can populate it with your custom classes, or it will be populated automatically when you choose any import option. List will be persisted, so it will be used next time you run the same project.
 

--- a/autoload/javacomplete/server.vim
+++ b/autoload/javacomplete/server.vim
@@ -80,6 +80,7 @@ function! javacomplete#server#Start()
     call s:Log("server arguments:". args)
 
     let file = g:JavaComplete_Home. g:FILE_SEP. "autoload". g:FILE_SEP. "javavibridge.py"
+    call s:Log("executing python file: " . file)
     execute "JavacompletePyfile ". file
 
     JavacompletePy import vim
@@ -141,7 +142,7 @@ function! javacomplete#server#Compile()
   call javacomplete#server#Terminate()
 
   let javaviDir = g:JavaComplete_Home. g:FILE_SEP. join(['libs', 'javavi'], g:FILE_SEP). g:FILE_SEP
-  if isdirectory(javaviDir. join(['target', 'classes'], g:FILE_SEP)) 
+  if isdirectory(javaviDir. join(['target', 'classes'], g:FILE_SEP))
     call javacomplete#util#RemoveFile(javaviDir.join(['target', 'classes'], g:FILE_SEP))
   endif
 
@@ -180,7 +181,7 @@ function! javacomplete#server#Communicate(option, args, log)
   endif
 
   if s:Poll()
-    if !empty(a:args) 
+    if !empty(a:args)
       let args = ' "'. substitute(a:args, '"', '\\"', 'g'). '"'
     else
       let args = ''

--- a/plugin/javacomplete.vim
+++ b/plugin/javacomplete.vim
@@ -101,6 +101,9 @@ nnoremap <Plug>(JavaComplete-Generate-EqualsAndHashCode) :call javacomplete#gene
 nnoremap <Plug>(JavaComplete-Generate-Constructor) :call javacomplete#generators#GenerateConstructor(0)<cr>
 nnoremap <Plug>(JavaComplete-Generate-DefaultConstructor) :call javacomplete#generators#GenerateConstructor(1)<cr>
 
+nnoremap <Plug>(JavaComplete-Imports-SortImports) :call javacomplete#imports#SortImports()<cr>
+inoremap <Plug>(JavaComplete-Imports-SortImports) <c-r>=<SID>nop(javacomplete#imports#SortImports())<cr>
+
 let &cpo = s:save_cpo
 unlet s:save_cpo
 " vim:set fdm=marker sw=2 nowrap:


### PR DESCRIPTION
The google style guide wants third party packages in between the project's packages and the standard library packages (see https://google.github.io/styleguide/javaguide.html#s3.3-import-statements).  This PR adds support for that by allowing a `*` character in the ImportOrder list, which will match any package not otherwise specified in the list.

This PR also makes sorting imports available as a <Plug> mapping in both normal and insert modes, as `<Plug>(JavaComplete-Imports-SortImports)`.  

Please don't feel obligated to incorporate this feature if it's not in line with your plan.  It's something I needed, and figured I should offer back just in case you wanted it.  If you need me to make modifications to this before merging, I'm open to that but will be traveling a lot in the next few weeks so may not be very responsive until mid August (2016).

Thank you!