### PR TITLE
Retrieve Android's classpath differently

### DIFF
--- a/classpath.gradle
+++ b/classpath.gradle
@@ -29,7 +29,7 @@ task classpath << {
         }
     }
     if (proj.hasProperty("android")){
-      classpathFiles += proj.android.bootClasspath
+      classpathFiles += proj.android.getBootClasspath()
     }
 
     if (proj.hasProperty("sourceSets")) {


### PR DESCRIPTION
by using android.getBootClasspath() instead of android.bootClasspath we get all jars used at runtime for android as well as using public API instead of the private API we were using before