### PR TITLE
Start server without shell

### DIFF
--- a/autoload/javacomplete/server.vim
+++ b/autoload/javacomplete/server.vim
@@ -74,24 +74,23 @@ function! javacomplete#server#Start()
     call add(javaProps, '-Ddaemon.port='. port)
 
     let classpath = substitute(javacomplete#server#GetClassPath(), '\\', '\\\\', 'g')
-    let sources = ''
+    let sources = []
     if exists('g:JavaComplete_SourcesPath')
-      let sources = '-sources "'. substitute(s:ExpandAllPaths(g:JavaComplete_SourcesPath), '\\', '\\\\', 'g'). '"'
+      let sources += ['-sources', s:ExpandAllPaths(g:JavaComplete_SourcesPath) ]
     endif
 
-    let args = ' kg.ash.javavi.Javavi '. sources
+    let args = javaProps + [ 'kg.ash.javavi.Javavi' ] + sources
     if exists('g:JavaComplete_ServerAutoShutdownTime')
-      let args .= ' -t '. g:JavaComplete_ServerAutoShutdownTime
+      let args += [ '-t', g:JavaComplete_ServerAutoShutdownTime ]
     endif
-    let args .= ' -base "'. substitute(javacomplete#util#GetBase(''), '\\', '\\\\', 'g'). '"'
-    let args .= ' -compiler "'. substitute(javacomplete#server#GetCompiler(), '\\', '\\\\', 'g'). '"'
+    let args += [ '-base', javacomplete#util#GetBase('') ]
+    let args += [ '-compiler', javacomplete#server#GetCompiler() ]
     if !empty(g:JavaComplete_ProjectKey)
-      let args .= ' -project "'. substitute(g:JavaComplete_ProjectKey, '\\', '\\\\', 'g'). '"'
+      let args += [ '-project', g:JavaComplete_ProjectKey ]
     endif
 
-    let args = ' '. join(javaProps, ' '). ' '. args
     call s:Log("server classpath: -cp ". classpath)
-    call s:Log("server arguments:". args)
+    call s:Log("server arguments:". join(args, ' '))
 
     JavacompletePy bridgeState = JavaviBridge()
     JavacompletePy bridgeState.setupServer(vim.eval('javacomplete#server#GetJVMLauncher()'), vim.eval('args'), vim.eval('classpath'))

--- a/autoload/javavibridge.py
+++ b/autoload/javavibridge.py
@@ -19,11 +19,11 @@ def GetUnusedLocalhostPort():
 SERVER = ('127.0.0.1', GetUnusedLocalhostPort())
 
 # A wrapper for subprocess.Popen that works around a Popen bug on Windows.
-def SafePopen(*args, **kwargs):
+def SafePopen(args, **kwargs):
     if kwargs.get('stdin') is None:
         kwargs['stdin'] = subprocess.PIPE if sys.platform == 'win32' else None
 
-    return subprocess.Popen( *args, **kwargs )
+    return subprocess.Popen( args, **kwargs )
 
 class JavaviBridge():
 
@@ -60,14 +60,15 @@ class JavaviBridge():
         else:
             output = subprocess.PIPE
 
-        shell = is_win == False
+        shell = False
+        args = [ javabin ] + args + [ '-D', str(SERVER[1]) ]
         if is_win and vim.eval('has("gui_running")'):
             info = subprocess.STARTUPINFO()
             info.dwFlags = 1
             info.wShowWindow = 0
-            self.popen = SafePopen(javabin + ' ' + args + ' -D ' + str(SERVER[1]), shell=shell, env=environ, stdout = output, stderr = output, startupinfo = info)
+            self.popen = SafePopen(args, shell=shell, env=environ, stdout = output, stderr = output, startupinfo = info)
         else:
-            self.popen = SafePopen(javabin + ' ' + args + ' -D ' + str(SERVER[1]), shell=shell, env=environ, stdout = output, stderr = output)
+            self.popen = SafePopen(args, shell=shell, env=environ, stdout = output, stderr = output)
 
     def pid(self):
         return self.popen.pid


### PR DESCRIPTION
Under debian stable with vim v7.4, the java server process is never killed when vim exit.

During editing java files, 2 process are unning:
user 23774  0.0  0.0   4356   812 pts/3    S+   14:57   0:00          \_ /bin/sh -c java  -Ddaemon.port=50255  kg.ash.javavi.Javavi -sources "sourcesDir/" -base "baseDir/" -compiler "javac" -D 50255
user 23776 40.7  1.7 4977920 140976 pts/3  Sl+  14:57   0:02              \_ java -Ddaemon.port=50255 kg.ash.javavi.Javavi -sources sourcesDir/ -base baseDir/ -compiler javac -D 50255

And after vim exit, the java process remain:
user 23776  4.3  1.7 4977920 140976 pts/3  Sl   14:57   0:02 java -Ddaemon.port=50255 kg.ash.javavi.Javavi -sources sourcesDir -base baseDir -compiler javac -D 50255

It looks like issue #234  but with vim.

When launching the java server process without shell, no shell is spawned and the java process is killed when vim exit.
