### PR TITLE
Redefine Gradle task and deduplicate classpath calls

### DIFF
--- a/autoload/javacomplete/classpath/classpath.vim
+++ b/autoload/javacomplete/classpath/classpath.vim
@@ -21,7 +21,7 @@ function! s:BuildClassPath(force)
       if filereadable(getcwd(). g:FILE_SEP. "build.gradle")
         let g:JavaComplete_GradlePath = getcwd(). g:FILE_SEP. "build.gradle"
       else
-        let g:JavaComplete_GradlePath = javacomplete#util#FindFile('build.gradle')
+        let g:JavaComplete_GradlePath = javacomplete#util#FindFile('build.gradle', '**3')
       endif
       if g:JavaComplete_GradlePath != ""
         let g:JavaComplete_GradlePath = fnamemodify(g:JavaComplete_GradlePath, ':p')

--- a/autoload/javacomplete/classpath/gradle.vim
+++ b/autoload/javacomplete/classpath/gradle.vim
@@ -76,15 +76,33 @@ function! s:GenerateClassPath(path, gradle) abort
   if exists("g:JavaComplete_GradleExecutable")
     let gradle = g:JavaComplete_GradleExecutable
   else
-    let gradle = fnamemodify(g:JavaComplete_GradlePath, ':p:h') . (javacomplete#util#IsWindows() ? '\gradlew.bat' : '/gradlew')
+    let gradle = fnamemodify(
+          \ g:JavaComplete_GradlePath, ':p:h') 
+          \ . (javacomplete#util#IsWindows() 
+          \ ? 
+          \ '\gradlew.bat' 
+          \ : 
+          \ '/gradlew')
     if !executable(gradle)
       let gradle = 'gradle'
     endif
   endif
-  call writefile(["rootProject{apply from: '". g:JavaComplete_Home. g:FILE_SEP. "classpath.gradle'}"], s:temporaryGradleFile)
-  let cmd = [gradle, '-I', s:temporaryGradleFile, 'classpath']
+  call writefile(
+        \ ["rootProject{apply from: '"
+        \ . g:JavaComplete_Home. g:FILE_SEP. "classpath.gradle'}"], 
+        \ s:temporaryGradleFile)
+  let cmd = [
+        \ gradle, 
+        \ '-p', 
+        \ fnamemodify(g:JavaComplete_GradlePath, ':p:h'), 
+        \ '-I', 
+        \ s:temporaryGradleFile, 
+        \ 'classpath']
   call javacomplete#server#BlockStart()
-  call javacomplete#util#RunSystem(cmd, 'gradle classpath build process', 'javacomplete#classpath#gradle#BuildClasspathHandler')
+  call javacomplete#util#RunSystem(
+        \ cmd, 
+        \ 'gradle classpath build process', 
+        \ 'javacomplete#classpath#gradle#BuildClasspathHandler')
 endfunction
 
 " vim:set fdm=marker sw=2 nowrap:

--- a/autoload/javacomplete/classpath/gradle.vim
+++ b/autoload/javacomplete/classpath/gradle.vim
@@ -81,7 +81,7 @@ function! s:GenerateClassPath(path, gradle) abort
       let gradle = 'gradle'
     endif
   endif
-  call writefile(["allprojects{apply from: '". g:JavaComplete_Home. g:FILE_SEP. "classpath.gradle'}"], s:temporaryGradleFile)
+  call writefile(["rootProject{apply from: '". g:JavaComplete_Home. g:FILE_SEP. "classpath.gradle'}"], s:temporaryGradleFile)
   let cmd = [gradle, '-I', s:temporaryGradleFile, 'classpath']
   call javacomplete#server#BlockStart()
   call javacomplete#util#RunSystem(cmd, 'gradle classpath build process', 'javacomplete#classpath#gradle#BuildClasspathHandler')

--- a/autoload/javacomplete/util.vim
+++ b/autoload/javacomplete/util.vim
@@ -189,11 +189,12 @@ function! javacomplete#util#CleanFQN(fqnDeclaration)
   return fqnDeclaration
 endfunction
 
-function! javacomplete#util#FindFile(what) abort
+function! javacomplete#util#FindFile(what, ...) abort
+  let direction = a:0 > 0 ? a:1 : ';'
   let old_suffixesadd = &suffixesadd
   try
     let &suffixesadd = ''
-    return findfile(a:what, escape(expand('.'), '*[]?{}, ') . ';')
+    return findfile(a:what, escape(expand('.'), '*[]?{}, ') . direction)
   finally
     let &suffixesadd = old_suffixesadd
   endtry

--- a/classpath.gradle
+++ b/classpath.gradle
@@ -1,46 +1,45 @@
-task classpath << {
-
-  String finalFileContents = ""
-  HashSet<String> classpathFiles = new HashSet<String>()
-  for (proj in allprojects) {
-    
-    def exploded = proj.getBuildDir().absolutePath + File.separator + "intermediates" + File.separator + "exploded-aar"
-    def listFiles = new File(exploded)
-    if (listFiles.exists()) {
-      listFiles.eachFileRecurse(){ file ->
-        if (file.name.endsWith(".jar")){
-          classpathFiles += file
+task classpath {
+  doLast {
+    String finalFileContents = ""
+    HashSet<String> classpathFiles = new HashSet<String>()
+    for (proj in allprojects) {
+      def exploded = proj.getBuildDir().absolutePath + File.separator + "intermediates" + File.separator + "exploded-aar"
+      def listFiles = new File(exploded)
+      if (listFiles.exists()) {
+        listFiles.eachFileRecurse(){ file ->
+          if (file.name.endsWith(".jar")) {
+            classpathFiles += file
+          }
         }
       }
-    }
 
-    def rjava = proj.getBuildDir().absolutePath + File.separator + "intermediates" + File.separator + "classes" + File.separator + "debug"
-    def rFiles = new File(rjava)
-    if (rFiles.exists()) {
-      classpathFiles += rFiles
-    }
+      def rjava = proj.getBuildDir().absolutePath + File.separator + "intermediates" + File.separator + "classes" + File.separator + "debug"
+      def rFiles = new File(rjava)
+      if (rFiles.exists()) {
+        classpathFiles += rFiles
+      }
 
-    for (conf in proj.configurations) {
-        for (dependency in conf) {
-            if (dependency.name.endsWith("aar")){
-            } else {
-              classpathFiles += dependency
-            }
-        }
-    }
-    if (proj.hasProperty("android")){
-      classpathFiles += proj.android.getBootClasspath()
-    }
-
-    if (proj.hasProperty("sourceSets")) {
-    
-      for (srcSet in proj.sourceSets) {
-          for (dir in srcSet.java.srcDirs) {
-              classpathFiles += dir.absolutePath
+      for (conf in proj.configurations) {
+          for (dependency in conf) {
+              if (dependency.name.endsWith("aar")) {
+              } else {
+                classpathFiles += dependency
+              }
           }
       }
+      if (proj.hasProperty("android")) {
+        classpathFiles += proj.android.getBootClasspath()
+      }
+
+      if (proj.hasProperty("sourceSets")) {
+        for (srcSet in proj.sourceSets) {
+            for (dir in srcSet.java.srcDirs) {
+                classpathFiles += dir.absolutePath
+            }
+        }
+      }
     }
+    def paths = classpathFiles.join(File.pathSeparator)
+    println "CLASSPATH:" + paths
   }
-  def paths = classpathFiles.join(File.pathSeparator)
-  println "CLASSPATH:" + paths
 }


### PR DESCRIPTION
1. Switch from << (leftShift) task definition that's been deprecated in Gradle to supported version
2. Define the classpath task for only the root project to remove duplicate calls for all sub projects