### PR TITLE
Fixed an error with SYNCHRONIZED block parsing.

### DIFF
--- a/autoload/java_parser.vim
+++ b/autoload/java_parser.vim
@@ -2494,7 +2494,7 @@ fu! s:statement()
     call s:nextToken()
     let lock = s:parExpression()
     let body = s:block()
-    return {'tag': 'SYNCHRONIZED', 'pos': pos, 'endpos': b:pos, 'lock': lock, 'cases': body}
+    return {'tag': 'SYNCHRONIZED', 'pos': pos, 'endpos': b:pos, 'lock': lock, 'body': body}
 
   elseif b:token == 'RETURN'
     call s:nextToken()


### PR DESCRIPTION
This is an old error that seems to exist since the initial commit.

Line 106 of parseradapter.vim assumes the dictionary entry is named 'block'.