### PR TITLE
GetServerAppVersion uses configured JVM, not system default.

### DIFF
--- a/autoload/javacomplete/server.vim
+++ b/autoload/javacomplete/server.vim
@@ -56,12 +56,12 @@ function! javacomplete#server#Terminate()
 endfunction
 
 function! s:GetServerAppVersion()
-  let classpath = 
-        \ s:GetJavaviClassPath(). g:PATH_SEP. 
+  let classpath =
+        \ s:GetJavaviClassPath(). g:PATH_SEP.
         \ s:GetJavaviDeps(). g:PATH_SEP
   return system(join(
         \ [
-          \ 'java', '-cp', classpath, 
+          \ javacomplete#server#GetJVMLauncher(), '-cp', classpath,
           \ 'kg.ash.javavi.Javavi -version'
         \ ]))
 endfunction


### PR DESCRIPTION
Noticed a stack trace in the logs and followed it back to this function.  Issue was that I have jenv configured to use Java 7 for a particular project and use `SetJVMLauncher` to point Javacomplete2 to the a Java 8 JVM, but the `GetServerAppVersion` wasn't honoring it.  Was faster to just fix than file a bug ;)