### PR TITLE
Fix sourcesets in during CLASSPATH generation

### DIFF
--- a/classpath.gradle
+++ b/classpath.gradle
@@ -31,7 +31,11 @@ task classpath {
         proj.android.applicationVariants.all { v ->
           classpathFiles += v.getApkLibraries()
           classpathFiles += v.getCompileLibraries()
-          classpathFiles += v.getSourceSets()
+          for (srcSet in v.getSourceSets()) {
+            for (dir in srcSet.java.srcDirs) {
+                classpathFiles += dir.absolutePath
+            }
+          }
         }
       }
 


### PR DESCRIPTION
Currently, the name of the sourceset is being put into the CLASSPATH instead of the filepath location. This change puts the actual filepath into the CLASSPATH