### PR TITLE
Fix Android projects that are libraries

### DIFF
--- a/classpath.gradle
+++ b/classpath.gradle
@@ -26,14 +26,28 @@ task classpath {
               }
           }
       }
+
       if (proj.hasProperty("android")) {
         classpathFiles += proj.android.getBootClasspath()
-        proj.android.applicationVariants.all { v ->
-          classpathFiles += v.getApkLibraries()
-          classpathFiles += v.getCompileLibraries()
-          for (srcSet in v.getSourceSets()) {
-            for (dir in srcSet.java.srcDirs) {
-                classpathFiles += dir.absolutePath
+        if (proj.android.hasProperty("applicationVariants")) {
+          proj.android.applicationVariants.all { v ->
+            classpathFiles += v.getApkLibraries()
+            classpathFiles += v.getCompileLibraries()
+            for (srcSet in v.getSourceSets()) {
+              for (dir in srcSet.java.srcDirs) {
+                  classpathFiles += dir.absolutePath
+              }
+            }
+          }
+        }
+
+        if (proj.android.hasProperty("libraryVariants")) {
+          proj.android.libraryVariants.all { v ->
+            classpathFiles += v.javaCompile.classpath.files
+            for (srcSet in v.getSourceSets()) {
+              for (dir in srcSet.java.srcDirs) {
+                  classpathFiles += dir.absolutePath
+              }
             }
           }
         }


### PR DESCRIPTION
Some Android projects are Libraries and do not have a "applicationVariants" property. This commit handles the case where that doesn't exist and handles the case of where there is a "libraryVariants" property to extract a classpath from