### PR TITLE
Allow to skip imports on class completion

### DIFF
--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -146,7 +146,7 @@ endfunction
 call s:SetCurrentFileKey()
 
 function! s:HandleTextChangedI()
-  if get(g:, 'JC_ClassnameCompletedFlag', 0)
+  if get(g:, 'JC_ClassnameCompletedFlag', 0) && get(g:, 'JavaComplete_InsertImports', 1)
     let saveCursor = getcurpos()
     let line = getline('.')
     if empty(javacomplete#util#Trim(line))

--- a/doc/javacomplete.txt
+++ b/doc/javacomplete.txt
@@ -293,6 +293,11 @@ A single letter indicates the kind of compeltion item. These kinds are:
     
         let g:JavaComplete_ImportDefault = -1
 
+    Import selection is activated automatically when completing new class
+    name. This can be avoided by setting:
+
+        let g:JavaComplete_InsertImports = 0
+
     Use your own executable file for gradle:
 
         let g:JavaComplete_GradleExecutable = 'gradle'


### PR DESCRIPTION
Personally, I find it quite annoying to have to reply to the import dialog after picking a completion option, so I added switch to disable this behavior.