### PR TITLE
Bugfix/get apk libraries not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ To add all missing imports with F6:
 
 `imap <F6> <Plug>(JavaComplete-Imports-AddMissing)`
 
-To remove all missing imports with F7:
+To remove all unused imports with F7:
 
 `nmap <F7> <Plug>(JavaComplete-Imports-RemoveUnused)`
 

--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -146,7 +146,7 @@ endfunction
 call s:SetCurrentFileKey()
 
 function! s:HandleTextChangedI()
-  if get(g:, 'JC_ClassnameCompletedFlag', 0)
+  if get(g:, 'JC_ClassnameCompletedFlag', 0) && get(g:, 'JavaComplete_InsertImports', 1)
     let saveCursor = getcurpos()
     let line = getline('.')
     if empty(javacomplete#util#Trim(line))

--- a/autoload/javacomplete/classpath/gradle.vim
+++ b/autoload/javacomplete/classpath/gradle.vim
@@ -1,16 +1,22 @@
 function! javacomplete#classpath#gradle#IfGradle()
   if exists("g:JavaComplete_GradleExecutable")
-    if executable(g:JavaComplete_GradleExecutable)
+    if executable(g:JavaComplete_GradleExecutable) && g:JavaComplete_GradlePath != ""
       return 1
     else
       return 0
     end
   endif
 
-  if g:JavaComplete_GradlePath != "" && (executable('gradle') || executable(fnamemodify(g:JavaComplete_GradlePath, ':p:h') . (javacomplete#util#IsWindows() ? '\gradlew.bat' : '/gradlew')))
+  if g:JavaComplete_GradlePath != "" && s:IsGradleExecutable() && g:JavaComplete_GradlePath != ""
     return 1
   endif
   return 0
+endfunction
+
+function! s:IsGradleExecutable() 
+  let osExec = javacomplete#util#IsWindows() ? '\gradlew.bat' : '/gradlew'
+  let path = fnamemodify(g:JavaComplete_GradlePath, ':p:h')
+  return executable('gradle') || executable(path. osExec)
 endfunction
 
 function! javacomplete#classpath#gradle#BuildClasspathHandler(data, event)

--- a/classpath.gradle
+++ b/classpath.gradle
@@ -41,8 +41,7 @@ task classpath {
         classpathFiles += proj.android.getBootClasspath()
         if (proj.android.hasProperty("applicationVariants")) {
           proj.android.applicationVariants.all { v ->
-            classpathFiles += v.getApkLibraries()
-            classpathFiles += v.getCompileLibraries()
+            classpathFiles += v.javaCompile.classpath.files
             for (srcSet in v.getSourceSets()) {
               for (dir in srcSet.java.srcDirs) {
                   classpathFiles += dir.absolutePath

--- a/classpath.gradle
+++ b/classpath.gradle
@@ -1,3 +1,11 @@
+boolean isResolvable(Configuration conf) {
+  // isCanBeResolved was added in Gradle 3.3. Previously, all configurations were resolvable
+  if (Configuration.class.declaredMethods.any { it.name == 'isCanBeResolved' }) {
+    return conf.canBeResolved
+  }
+  return true
+}
+
 task classpath {
   doLast {
     HashSet<String> classpathFiles = new HashSet<String>()
@@ -19,12 +27,14 @@ task classpath {
       }
 
       for (conf in proj.configurations) {
+        if (isResolvable(conf)) {
           for (dependency in conf) {
               if (dependency.name.endsWith("aar")) {
               } else {
                 classpathFiles += dependency
               }
           }
+        }
       }
 
       if (proj.hasProperty("android")) {

--- a/classpath.gradle
+++ b/classpath.gradle
@@ -26,14 +26,28 @@ task classpath {
               }
           }
       }
+
       if (proj.hasProperty("android")) {
         classpathFiles += proj.android.getBootClasspath()
-        proj.android.applicationVariants.all { v ->
-          classpathFiles += v.getApkLibraries()
-          classpathFiles += v.getCompileLibraries()
-          for (srcSet in v.getSourceSets()) {
-            for (dir in srcSet.java.srcDirs) {
-                classpathFiles += dir.absolutePath
+        if (proj.android.hasProperty("applicationVariants")) {
+          proj.android.applicationVariants.all { v ->
+            classpathFiles += v.getApkLibraries()
+            classpathFiles += v.getCompileLibraries()
+            for (srcSet in v.getSourceSets()) {
+              for (dir in srcSet.java.srcDirs) {
+                  classpathFiles += dir.absolutePath
+              }
+            }
+          }
+        }
+
+        if (proj.android.hasProperty("libraryVariants")) {
+          proj.android.libraryVariants.all { v ->
+            classpathFiles += v.javaCompile.classpath.files
+            for (srcSet in v.getSourceSets()) {
+              for (dir in srcSet.java.srcDirs) {
+                  classpathFiles += dir.absolutePath
+              }
             }
           }
         }

--- a/doc/javacomplete.txt
+++ b/doc/javacomplete.txt
@@ -293,6 +293,11 @@ A single letter indicates the kind of compeltion item. These kinds are:
     
         let g:JavaComplete_ImportDefault = -1
 
+    Import selection is activated automatically when completing new class
+    name. This can be avoided by setting:
+
+        let g:JavaComplete_InsertImports = 0
+
     Use your own executable file for gradle:
 
         let g:JavaComplete_GradleExecutable = 'gradle'

--- a/libs/javavi/src/main/java/kg/ash/javavi/Javavi.java
+++ b/libs/javavi/src/main/java/kg/ash/javavi/Javavi.java
@@ -13,7 +13,7 @@ import kg.ash.javavi.searchers.ClasspathCollector;
 
 public class Javavi {
 
-    public static final String VERSION	= "2.3.7.2";
+    public static final String VERSION	= "2.3.7.3";
 
     public static String NEWLINE = "";
 


### PR DESCRIPTION
With the android gradle plugin 3.0.0.beta4, I got an error that getApkLibraries() doesn't exist.  This seems to solve the issue, but I didn't test it with older versions of the plugin.