### PR TITLE
Fix gradle cache

### DIFF
--- a/classpath.gradle
+++ b/classpath.gradle
@@ -6,6 +6,15 @@ boolean isResolvable(Configuration conf) {
   return true
 }
 
+Collection getBuildCacheForDependency(File dependency) {
+  String name = dependency.getName()
+  String home = System.getProperty("user.home")
+  String gradleCache = home + '/.gradle/caches'
+  String include = '**/' + name +  '/**/classes.jar'
+  String exclude = '**/**'
+  return fileTree(dir: gradleCache, include: include).files.findAll { it.isFile() }
+}
+
 task classpath {
   doLast {
     HashSet<String> classpathFiles = new HashSet<String>()
@@ -16,11 +25,7 @@ task classpath {
             if (dependency.name.endsWith("jar")) {
               classpathFiles += dependency
             } else {
-              zipTree(dependency).each { explodedFile ->
-                if (explodedFile.toString().endsWith("jar")) {
-                  classpathFiles += explodedFile
-                }
-              }
+              classpathFiles += getBuildCacheForDependency(dependency)
             }
           }
         }
@@ -41,11 +46,7 @@ task classpath {
                 if (dependency.name.endsWith("jar")) {
                   classpathFiles += dependency
                 } else {
-                  zipTree(dependency).each { explodedFile ->
-                    if (explodedFile.toString().endsWith("jar")) {
-                      classpathFiles += explodedFile
-                    }
-                  }
+                  classpathFiles += getBuildCacheForDependency(dependency)
                 }
               }
             }
@@ -54,11 +55,7 @@ task classpath {
                 if (dependency.name.endsWith("jar")) {
                   classpathFiles += dependency
                 } else {
-                  zipTree(dependency).each { explodedFile ->
-                    if (explodedFile.toString().endsWith("jar")) {
-                      classpathFiles += explodedFile
-                    }
-                  }
+                  classpathFiles += getBuildCacheForDependency(dependency)
                 }
               }
             }
@@ -69,6 +66,7 @@ task classpath {
               classpathFiles += v.getCompileLibraries()
             }
             for (srcSet in v.getSourceSets()) {
+            srcSet.properties.each { prop -> println prop }
               for (dir in srcSet.java.srcDirs) {
                   classpathFiles += dir.absolutePath
               }
@@ -97,7 +95,7 @@ task classpath {
       }
     }
     def paths = classpathFiles.join(File.pathSeparator)
-    println "CLASSPATH:" + paths
-    println "END CLASSPATH GENERATION"
+    // println "CLASSPATH:" + paths
+    // println "END CLASSPATH GENERATION"
   }
 }

--- a/classpath.gradle
+++ b/classpath.gradle
@@ -10,9 +10,12 @@ Collection getBuildCacheForDependency(File dependency) {
   String name = dependency.getName()
   String home = System.getProperty("user.home")
   String gradleCache = home + '/.gradle/caches'
-  String include = '**/' + name +  '/**/classes.jar'
-  String exclude = '**/**'
-  return fileTree(dir: gradleCache, include: include).files.findAll { it.isFile() }
+  if (file(gradleCache).exists()) {
+    String include = '**/' + name +  '/**/classes.jar'
+    return fileTree(dir: gradleCache, include: include).files.findAll { it.isFile() }
+  } else {
+    return zipTree(dependency)
+  }
 }
 
 task classpath {
@@ -66,7 +69,6 @@ task classpath {
               classpathFiles += v.getCompileLibraries()
             }
             for (srcSet in v.getSourceSets()) {
-            srcSet.properties.each { prop -> println prop }
               for (dir in srcSet.java.srcDirs) {
                   classpathFiles += dir.absolutePath
               }
@@ -95,7 +97,7 @@ task classpath {
       }
     }
     def paths = classpathFiles.join(File.pathSeparator)
-    // println "CLASSPATH:" + paths
-    // println "END CLASSPATH GENERATION"
+    println "CLASSPATH:" + paths
+    println "END CLASSPATH GENERATION"
   }
 }

--- a/classpath.gradle
+++ b/classpath.gradle
@@ -10,12 +10,18 @@ task classpath {
   doLast {
     HashSet<String> classpathFiles = new HashSet<String>()
     for (proj in allprojects) {
-      def exploded = proj.getBuildDir().absolutePath + File.separator + "intermediates" + File.separator + "exploded-aar"
-      def listFiles = new File(exploded)
-      if (listFiles.exists()) {
-        listFiles.eachFileRecurse(){ file ->
-          if (file.name.endsWith(".jar")) {
-            classpathFiles += file
+      for (conf in proj.configurations) {
+        if (isResolvable(conf)) {
+          for (dependency in conf) {
+            if (dependency.name.endsWith("jar")) {
+              classpathFiles += dependency
+            } else {
+              zipTree(dependency).each { explodedFile ->
+                if (explodedFile.toString().endsWith("jar")) {
+                  classpathFiles += explodedFile
+                }
+              }
+            }
           }
         }
       }
@@ -26,23 +32,42 @@ task classpath {
         classpathFiles += rFiles
       }
 
-      for (conf in proj.configurations) {
-        if (isResolvable(conf)) {
-          for (dependency in conf) {
-              if (dependency.name.endsWith("aar")) {
-              } else {
-                classpathFiles += dependency
-              }
-          }
-        }
-      }
-
       if (proj.hasProperty("android")) {
         classpathFiles += proj.android.getBootClasspath()
         if (proj.android.hasProperty("applicationVariants")) {
           proj.android.applicationVariants.all { v ->
-            classpathFiles += v.getApkLibraries()
-            classpathFiles += v.getCompileLibraries()
+            if (v.hasProperty("compileConfiguration")) {
+              v.compileConfiguration.each { dependency ->
+                if (dependency.name.endsWith("jar")) {
+                  classpathFiles += dependency
+                } else {
+                  zipTree(dependency).each { explodedFile ->
+                    if (explodedFile.toString().endsWith("jar")) {
+                      classpathFiles += explodedFile
+                    }
+                  }
+                }
+              }
+            }
+            if (v.hasProperty("runtimeConfiguration")) {
+              v.runtimeConfiguration.each { dependency ->
+                if (dependency.name.endsWith("jar")) {
+                  classpathFiles += dependency
+                } else {
+                  zipTree(dependency).each { explodedFile ->
+                    if (explodedFile.toString().endsWith("jar")) {
+                      classpathFiles += explodedFile
+                    }
+                  }
+                }
+              }
+            }
+            if (v.hasProperty("getApkLibraries")) {
+              classpathFiles += v.getApkLibraries()
+            }
+            if (v.hasProperty("getCompileLibraries")) {
+              classpathFiles += v.getCompileLibraries()
+            }
             for (srcSet in v.getSourceSets()) {
               for (dir in srcSet.java.srcDirs) {
                   classpathFiles += dir.absolutePath


### PR DESCRIPTION
Fixes #325 

Possibly makes this support the Gradle cache with some minor caveats.

1. Doesn't support Windows
2. Possibly reduces compatibility with pre-Gradle 4.0 but _should_ still work
3. It takes a long time to run (~45s with lots of dependencies)
4. Rather naive at this point

Note: It needs some cleanup, and I'm hoping to get some tests from others before this gets merged 

Edit: please merge 