### PR TITLE
Add Option to Sort Static Imports First

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Default mappings:
 
 `let g:JavaComplete_ImportSortType = 'jarName'` - imports sorting type. Sorting can be by jar archives `jarName` or by package names `packageName`.
 
+`let g:JavaComplete_StaticImportsAtTop = 1` - imports sorting with static imports at the top. By default this is `0`.
+
 `let g:JavaComplete_ImportOrder = ['java.', 'javax.', 'com.', 'org.', 'net.']` - Specifies the order of import groups, when use `packageName` sorting type.  An import group is a list of individual import statements that all start with the same beginning of package name surrounded by blank lines above and below the group. A `*` indicates all packages not specified, for 'google style' import ordering, e.g. `let g:JavaComplete_ImportOrder = ['com.google.', *, 'java.', 'javax.']`
 
 `let g:JavaComplete_RegularClasses = ['java.lang.String', 'java.lang.Object']` - Regular class names that will be used automatically when you insert import. You can populate it with your custom classes, or it will be populated automatically when you choose any import option. List will be persisted, so it will be used next time you run the same project.

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -189,6 +189,10 @@ function! javacomplete#imports#SortImports()
     call sort(importsList)
     let importsListSorted = s:SortImportsList(importsList)
 
+    if g:JavaComplete_StaticImportsAtTop
+      let importsListSorted = s:StaticImportsFirst(importsListSorted)
+    endif
+
     let saveCursor = getpos('.')
     silent execute beginLine.','.lastLine. 'delete _'
     for imp in importsListSorted
@@ -305,6 +309,21 @@ endfunction
 if !exists('s:RegularClassesDict') && exists('g:JavaComplete_RegularClasses')
   let s:RegularClassesDict = javacomplete#util#GetRegularClassesDict(g:JavaComplete_RegularClasses)
 endif
+
+function! s:StaticImportsFirst(importsList)
+  let staticImportsList = []
+  let l_a = copy(a:importsList)
+  for imp in l_a
+    if imp =~ '^static'
+      call remove(a:importsList, index(a:importsList, imp))
+      call add(staticImportsList, imp)
+    endif
+  endfor
+  if len(staticImportsList) > 0
+    call add(staticImportsList, '')
+  endif
+  return staticImportsList + a:importsList
+endfunction
 
 function! s:SortImportsList(importsList, ...)
   let sortType = a:0 > 0 ? a:1 : g:JavaComplete_ImportSortType

--- a/doc/javacomplete.txt
+++ b/doc/javacomplete.txt
@@ -342,6 +342,11 @@ A single letter indicates the kind of compeltion item. These kinds are:
 	let g:JavaComplete_CustomTemplateDirectory = '~/jc_templates'
 	By default this options is null.
 
+    Order imports such that static imports are at the top:
+
+        let g:JavaComplete_StaticImportsAtTop = '1' 
+        By default this options is 0.
+
 
 
 2.4 Commands					*javacomplete-commands*

--- a/plugin/javacomplete.vim
+++ b/plugin/javacomplete.vim
@@ -38,6 +38,9 @@ let g:JavaComplete_ImportSortType =
 let g:JavaComplete_ImportOrder =
       \ get(g:, 'JavaComplete_ImportOrder', ['java.', 'javax.', 'com.', 'org.', 'net.'])
 
+let g:JavaComplete_StaticImportsAtTop =
+      \ get(g:, 'JavaComplete_StaticImportsAtTop', 0)
+
 let g:JavaComplete_RegularClasses =
       \ get(g:, 'JavaComplete_RegularClasses', ['java.lang.String', 'java.lang.Object', 'java.lang.Exception', 'java.lang.StringBuilder', 'java.lang.Override', 'java.lang.UnsupportedOperationException', 'java.math.BigDecimal', 'java.lang.Byte', 'java.lang.Short', 'java.lang.Integer', 'java.lang.Long', 'java.lang.Float', 'java.lang.Double', 'java.lang.Character', 'java.lang.Boolean'])
 


### PR DESCRIPTION
This PR adds an option: `g:JavaComplete_StaticImportsAtTop` to sort the imports list with `static` imports first. By default this option is `0`.

The motivation for this option is to match the import order of IntelliJ.

