### PR TITLE
Fix a parser bug for maven classpath

### DIFF
--- a/autoload/javacomplete/classpath/maven.vim
+++ b/autoload/javacomplete/classpath/maven.vim
@@ -55,7 +55,7 @@ function! s:ParseMavenOutput()
     if s:mavenSettingsOutput[i] =~ 'Dependencies classpath:'
       let mvnProperties['project.dependencybuildclasspath'] = s:mavenSettingsOutput[i + 1]
       let offset = 2
-      while s:mavenSettingsOutput[i + offset] !~ '^[INFO.*' && offset <= 10
+      while s:mavenSettingsOutput[i + offset] !~ '^[INFO.*'
         let mvnProperties['project.dependencybuildclasspath'] .= s:mavenSettingsOutput[i + offset]
         let offset += 1
       endwhile


### PR DESCRIPTION
Currently, the plugin fails to parse all classpaths from maven if pom.xml has a lot of classpaths (i.e. https://gist.github.com/chiwanpark/5df218280df53de7356172a2540229c5). This pull request fixes the bug by removing offset.