### PR TITLE
Fix #383

### DIFF
--- a/autoload/javacomplete/server.vim
+++ b/autoload/javacomplete/server.vim
@@ -190,7 +190,7 @@ function! javacomplete#server#Compile()
 
   let s:compilationIsRunning = 1
   if executable('mvn')
-    let command = ['mvn', '-f', '"'. javaviDir. g:FILE_SEP. 'pom.xml"', 'compile']
+    let command = ['mvn', '-f', '"'. javaviDir. 'pom.xml"', 'compile']
   else
     call mkdir(javaviDir. join(['target', 'classes'], g:FILE_SEP), "p")
     let deps = s:GetJavaviDeps()


### PR DESCRIPTION
the `javaviDir` is end with g:FILE_SEP

so not need to add extra g:FILE_SEP
