### PR TITLE
fix error when mvn reads the pom.xml

### DIFF
--- a/autoload/javacomplete/classpath/maven.vim
+++ b/autoload/javacomplete/classpath/maven.vim
@@ -27,7 +27,7 @@ function! javacomplete#classpath#maven#Generate(force) abort
     let s:mavenPath = path
     let s:mavenPom = g:JavaComplete_PomPath
     let s:mavenSettingsOutput = []
-    let mvnCmd = ['mvn', '--file', g:JavaComplete_PomPath, 'help:effective-pom', 'dependency:build-classpath', '-DincludeScope=test']
+    let mvnCmd = ['mvn', '-B', '--file', g:JavaComplete_PomPath, 'help:effective-pom', 'dependency:build-classpath', '-DincludeScope=test']
     call javacomplete#server#BlockStart()
     call javacomplete#util#RunSystem(mvnCmd, 'maven classpath build process', 'javacomplete#classpath#maven#BuildClasspathHandler')
     return ""

--- a/autoload/javacomplete/server.vim
+++ b/autoload/javacomplete/server.vim
@@ -190,7 +190,7 @@ function! javacomplete#server#Compile()
 
   let s:compilationIsRunning = 1
   if executable('mvn')
-    let command = ['mvn', '-f', '"'. javaviDir. g:FILE_SEP. 'pom.xml"', 'compile']
+    let command = ['mvn', '-B', '-f', javaviDir. g:FILE_SEP. 'pom.xml', 'compile']
   else
     call mkdir(javaviDir. join(['target', 'classes'], g:FILE_SEP), "p")
     let deps = s:GetJavaviDeps()


### PR DESCRIPTION
Fix for #383 
- Removes double quotes around the pom.xml path
- Added '-B' parameter to mvn so the output is not colorized