### PR TITLE
Adds regex option to exclude matching class names from import list

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ let g:JavaComplete_EnableDefaultMappings = 0
 
 `let g:JavaComplete_CheckServerVersionAtStartup = 0` - Check server version on startup. Can be disabled on slow start, or infinite recompilation. By default it is 1.
 
+`let g:JavaComplete_ExcludeClassRegex = 'regex of classes to exclude'` - Exclude matching fully qualified class names from producing import statements.
+
 ## Commands
 
 `JCimportsAddMissing` - add all missing 'imports';

--- a/autoload/javacomplete/imports.vim
+++ b/autoload/javacomplete/imports.vim
@@ -213,6 +213,12 @@ function! javacomplete#imports#SortImports()
 endfunction
 
 function! s:AddImport(import)
+  if exists('g:JavaComplete_ExcludeClassRegex')
+    if a:import =~ get(g:, 'JavaComplete_ExcludeClassRegex')
+      return
+    endif
+  endif
+
   let isStaticImport = a:import =~ "^static.*" ? 1 : 0
   let import = substitute(a:import, "\\$", ".", "g")
   if !isStaticImport


### PR DESCRIPTION
I needed a way to prevent some classes from being added to to import list -- specifically `lombok.experimental.var`. This lets me add the following in my .vimrc

```vim
" Prevent `lombok.exprimental.var` from getting added to the imports
let g:JavaComplete_ExcludeClassRegex = 'lombok\(\.experimental\)\?\.var'
```