### PR TITLE
A small fix to make g:JavaComplete_ClasspathGenerationOrder configable.

### DIFF
--- a/plugin/javacomplete.vim
+++ b/plugin/javacomplete.vim
@@ -30,7 +30,7 @@ let g:JavaComplete_ShowExternalCommandsOutput =
       \ get(g:, 'JavaComplete_ShowExternalCommandsOutput', 0)
 
 let g:JavaComplete_ClasspathGenerationOrder =
-      \ get(g:, 'g:JavaComplete_ClasspathGenerationOrder', ['Eclipse', 'Maven', 'Gradle', 'Ant'])
+      \ get(g:, 'JavaComplete_ClasspathGenerationOrder', ['Eclipse', 'Maven', 'Gradle', 'Ant'])
 
 let g:JavaComplete_ImportSortType =
       \ get(g:, 'JavaComplete_ImportSortType', 'jarName')


### PR DESCRIPTION
I have double-checked that set g:JavaComplete_ClasspathGenerationOrder did not work, so the small pr is here. 