### PR TITLE
Strip drive letter segment from Windows pathnames

### DIFF
--- a/autoload/javacomplete/newclass.vim
+++ b/autoload/javacomplete/newclass.vim
@@ -162,6 +162,9 @@ function! javacomplete#newclass#CreateInFile()
 
   let currentPath = split(expand('%:p:h'), g:FILE_SEP)
   call filter(currentPath, 'empty(v:val) == 0')
+  if has('win32') && currentPath[0][-1:] ==':'
+    let currentPath = currentPath[1:]
+  endif
 
   let data = {}
   let data['path'] = ''
@@ -217,6 +220,9 @@ function! javacomplete#newclass#CreateClass()
   let currentPackage = split(javacomplete#collector#GetPackageName(), '\.')
   let currentPath = split(expand('%:p:h'), g:FILE_SEP)
   call filter(currentPath, 'empty(v:val) == 0')
+  if has('win32') && currentPath[0][-1:] ==':'
+    let currentPath = currentPath[1:]
+  endif
   let data = s:ParseInput(
         \ userinput, reverse(copy(currentPath)), currentPackage)
   if type(data) != type({})


### PR DESCRIPTION
This is a proposed fix for the problem described in issue [https://github.com/artur-shaik/vim-javacomplete2/issues/449].  Here is the description copied from the issue.

> 
> On a Windows 10 workstation, when I run the JCclassInFile or JCclassNew commands, javacomplete2 generates the wrong pathname for the new class because of the leading drive letter in Windows pathnames. A vim buffer is then created with an incorrect pathname and various vim errors are displayed. The error details are different in vim and neovim.
> 
> Example: I have a project in a directory C:\Users\fwy\test-project\ with a valid pom.xml file. (I am using Maven.) I have set this directory as my current vim directory. Inside this project is the subdirectory src\main\java.
> 
> In vim, the following messages are displayed if I run JCclassnew within the src\main\java directory, entering the new class name 'MyClass'.
> 
> Error detected while processing javacomplete#newclass#CreateClass[19]..209_CreateClass:
> Line 7:
> E739: Cannot create directory: \C:\Users
> "C:\C:\Users\fwy\test-project\src\main\java\MyClass.java [New DIRECTORY]
> 
> In addition, a buffer containing the generated source code is created with the pathname '\C:\Users\fwy\test-project\src\main\MyClass.java'. A new empty directory 'C' is also created directly under the C drive.
> 
> In neovim, I don't see the error messages, but the same buffer and directory are created.


The proposed fix is not the same one mentioned in the issue description.  I tried to make it more specific to the bad use case by modifying the pathname of the new class only when (a) the platform in Windows (win32), and (b) the first segment of the pathname ends with a colon character.  Only the functions javacomplete#newclass#CreateInFile() and javacomplete#newclass#CreateClass() are affected.

I tested the change on Windows and Linux with both Neovim and Vim, and it seems to work fine.  I don't have a Mac and didn't test on that platform.

Please let me know if you see any problems with it.  BTW, I rely heavily on vim-javacomplete2 and am sure that I would not be able to use vim for Java development without it.  Thanks for all the work you must have put into it!
