### PR TITLE
Enable JC and start server before JCclassNew

### DIFF
--- a/autoload/javacomplete/newclass.vim
+++ b/autoload/javacomplete/newclass.vim
@@ -210,6 +210,8 @@ function! s:DeterminePackage(currentPath)
 endfunction
 
 function! javacomplete#newclass#CreateClass()
+  call javacomplete#Enable()
+  call javacomplete#Start()
   let message = "enter new class name: "
   let userinput = input(message, '', 'customlist,javacomplete#newclass#Completion')
   if empty(userinput)


### PR DESCRIPTION
This is small convenience enhancement.  On occasion I have wanted to generate a new class using the JCclassNew command in a vim session before having opened any Java source files, and therefore before vim-javacomplete2 was enabled or the javavi server was started automatically.  In this case, various errors are written by vim.  Also, if the current directory was not already set to a location within my Java project where a pom.xml file could be found, there is the further side effect of the plugin scanning my entire machine for JARs to load into the classpath, greatly inflating Java memory usage.  Of course, it is always possible to set the current directory, enable JC and start the server by running JCEnable and JCServerStart manually, but I almost always forget to do this.  In this patch I automatically enable JC and start the server when the JCclassNew command is executed, before beginning the class generation logic.  This tends to prevent all the spurious error messages.

There may be other commands in the plugin that could benefit from this kind of change, but in my own experience it has only been an issue with JCclassNew.

I tested the change in neovim and vim on Windows and Linux, and it worked OK with no apparent side effects.  I don't have a Mac and didn't test on that platform.