### PR TITLE
Fix error message for empty class loaded when execute JCimportSort

### DIFF
--- a/autoload/javacomplete/util.vim
+++ b/autoload/javacomplete/util.vim
@@ -350,6 +350,15 @@ function! javacomplete#util#GetBase(extra)
   return base
 endfunction
 
+function! javacomplete#util#RemoveEmptyClasses(classes)
+  let newClasses = a:classes[:]
+  let emptyClassIndex = index(newClasses, '')
+  if emptyClassIndex > -1
+    unlet newClasses[emptyClassIndex]
+  endif
+  return newClasses
+endfunction
+
 function! javacomplete#util#GetRegularClassesDict(classes)
   let path = javacomplete#util#GetBase('cache'). g:FILE_SEP. 'regular_classes_'. g:JavaComplete_ProjectKey. '.dat'
   if filereadable(path)
@@ -357,7 +366,7 @@ function! javacomplete#util#GetRegularClassesDict(classes)
   else
     let classes = []
   endif
-  let classes = javacomplete#util#uniq(sort(extend(classes, a:classes)))
+  let classes = javacomplete#util#RemoveEmptyClasses(javacomplete#util#uniq(sort(extend(classes, a:classes))))
   let dict = {}
   for class in classes
     call extend(dict, {split(class,'\.')[-1] : class})

--- a/autoload/javacomplete/util.vim
+++ b/autoload/javacomplete/util.vim
@@ -352,11 +352,7 @@ endfunction
 
 function! javacomplete#util#RemoveEmptyClasses(classes)
   let newClasses = a:classes[:]
-  let emptyClassIndex = index(newClasses, '')
-  if emptyClassIndex > -1
-    unlet newClasses[emptyClassIndex]
-  endif
-  return newClasses
+  return filter(newClasses, 'v:val !~ "^$"')
 endfunction
 
 function! javacomplete#util#GetRegularClassesDict(classes)


### PR DESCRIPTION
Vim show an error message when execute "JCimportSort" command first time, but execute the command.
This pull request fix this error, related on issue #453.